### PR TITLE
fix: bug when the kubeconfig location is default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,5 @@ node_modules
 target/*
 target*/*
 target*
-frontend/dist/** */
+frontend/dist/**
 

--- a/crates/kftray-tauri/src/kubeforward/kubecontext.rs
+++ b/crates/kftray-tauri/src/kubeforward/kubecontext.rs
@@ -55,7 +55,8 @@ pub async fn create_client_with_specific_context(
                 default_path
             );
 
-            Kubeconfig::read().context("Failed to read kubeconfig from default location")?
+            Kubeconfig::read_from(default_path)
+                .context("Failed to read kubeconfig from default location")?
         } else {
             // Otherwise, try to read the kubeconfig from the specified path
             println!("Reading kubeconfig from specified path: {}", path);
@@ -71,7 +72,8 @@ pub async fn create_client_with_specific_context(
             default_path
         );
 
-        Kubeconfig::read().context("Failed to read kubeconfig from default location")?
+        Kubeconfig::read_from(default_path)
+            .context("Failed to read kubeconfig from default location")?
     };
 
     println!("create_client_with_specific_context2 {:?}", kubeconfig);


### PR DESCRIPTION
fix: bug when the kubeconfig location is default

When starting port forwarding configuration with the default Kubernetes context, the client is created with a specific context and fails to start for contexts that were not the active one.