### PR TITLE
fix: add network monitor to auto-reconnect port forwards after sleep/wake

### DIFF
--- a/crates/kftray-tauri/src/init_check.rs
+++ b/crates/kftray-tauri/src/init_check.rs
@@ -27,7 +27,6 @@ use sysinfo::{
     Pid,
     System,
 };
-use tokio;
 
 async fn fetch_configs_in_parallel(
     running_configs: Vec<ConfigState>,

--- a/crates/kftray-tauri/src/main.rs
+++ b/crates/kftray-tauri/src/main.rs
@@ -16,6 +16,7 @@ use log::{
 mod commands;
 mod init_check;
 mod logging;
+mod network_monitor;
 mod tray;
 mod window;
 
@@ -32,6 +33,7 @@ use tauri::{
 use tokio::runtime::Runtime;
 
 use crate::commands::portforward::check_and_emit_changes;
+use crate::network_monitor::start_network_monitor;
 use crate::tray::{
     create_tray_menu,
     handle_run_event,
@@ -106,6 +108,10 @@ fn main() {
             let app_handle_clone = app_handle.clone();
             tauri::async_runtime::spawn(async move {
                 check_and_emit_changes(app_handle_clone).await;
+            });
+
+            tauri::async_runtime::spawn(async move {
+                start_network_monitor().await;
             });
 
             #[cfg(target_os = "macos")]

--- a/crates/kftray-tauri/src/network_monitor.rs
+++ b/crates/kftray-tauri/src/network_monitor.rs
@@ -1,0 +1,53 @@
+use std::time::Duration;
+
+use kftray_portforward::port_forward::CANCEL_NOTIFIER;
+use log::info;
+use tokio::time::{
+    sleep,
+    timeout,
+};
+
+pub async fn start_network_monitor() {
+    info!("Starting network monitor");
+
+    let mut was_network_up = check_network().await;
+
+    loop {
+        sleep(Duration::from_secs(5)).await;
+
+        let is_network_up = check_network().await;
+
+        if !was_network_up && is_network_up {
+            info!("Network reconnected - likely wake from sleep");
+            handle_reconnect().await;
+        } else if was_network_up && !is_network_up {
+            info!("Network disconnected - possibly entering sleep");
+        }
+
+        was_network_up = is_network_up;
+    }
+}
+
+async fn check_network() -> bool {
+    let connectivity_check = tokio::spawn(async {
+        if let Ok(socket) = tokio::net::TcpStream::connect("8.8.8.8:53").await {
+            drop(socket);
+            true
+        } else {
+            false
+        }
+    });
+
+    match timeout(Duration::from_secs(1), connectivity_check).await {
+        Ok(Ok(result)) => result,
+        _ => false,
+    }
+}
+
+async fn handle_reconnect() {
+    info!("Triggering port forward reconnection after network change");
+
+    CANCEL_NOTIFIER.notify_waiters();
+
+    info!("Network change handled - UI will reconnect active connections");
+}

--- a/crates/kftray-tauri/src/network_monitor.rs
+++ b/crates/kftray-tauri/src/network_monitor.rs
@@ -1,6 +1,8 @@
+use std::sync::Arc;
 use std::time::Duration;
 
 use kftray_portforward::port_forward::CANCEL_NOTIFIER;
+use log::error;
 use log::info;
 use tokio::time::{
     sleep,
@@ -49,5 +51,83 @@ async fn handle_reconnect() {
 
     CANCEL_NOTIFIER.notify_waiters();
 
-    info!("Network change handled - UI will reconnect active connections");
+    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+
+    match kftray_commons::utils::config_state::get_configs_state().await {
+        Ok(config_states) => {
+            let active_config_ids: Vec<i64> = config_states
+                .into_iter()
+                .filter(|state| state.is_running)
+                .map(|state| state.config_id)
+                .collect();
+
+            if !active_config_ids.is_empty() {
+                info!(
+                    "Found {} active port forward configs to restart",
+                    active_config_ids.len()
+                );
+
+                let mut configs_to_restart = Vec::new();
+                for config_id in active_config_ids {
+                    match kftray_commons::config::get_config(config_id).await {
+                        Ok(config) => {
+                            configs_to_restart.push(config);
+                        }
+                        Err(e) => {
+                            error!("Failed to get config {}: {}", config_id, e);
+                        }
+                    }
+                }
+
+                let http_log_state = Arc::new(kftray_http_logs::HttpLogState::new());
+
+                let tcp_configs = configs_to_restart
+                    .iter()
+                    .filter(|c| c.protocol == "tcp")
+                    .cloned()
+                    .collect::<Vec<_>>();
+
+                if !tcp_configs.is_empty() {
+                    info!("Restarting {} TCP port forwards", tcp_configs.len());
+                    match kftray_portforward::kube::start_port_forward(
+                        tcp_configs,
+                        "tcp",
+                        http_log_state.clone(),
+                    )
+                    .await
+                    {
+                        Ok(_) => info!("Successfully restarted TCP port forwards"),
+                        Err(e) => error!("Failed to restart TCP port forwards: {}", e),
+                    }
+                }
+
+                let udp_configs = configs_to_restart
+                    .iter()
+                    .filter(|c| c.protocol == "udp")
+                    .cloned()
+                    .collect::<Vec<_>>();
+
+                if !udp_configs.is_empty() {
+                    info!("Restarting {} UDP port forwards", udp_configs.len());
+                    match kftray_portforward::kube::start_port_forward(
+                        udp_configs,
+                        "udp",
+                        http_log_state.clone(),
+                    )
+                    .await
+                    {
+                        Ok(_) => info!("Successfully restarted UDP port forwards"),
+                        Err(e) => error!("Failed to restart UDP port forwards: {}", e),
+                    }
+                }
+            } else {
+                info!("No active port forwards to restart");
+            }
+        }
+        Err(e) => {
+            error!("Failed to get config states: {}", e);
+        }
+    }
+
+    info!("Network reconnection handling completed");
 }


### PR DESCRIPTION
adds network monitoring that detects network state changes and automatically reconnects port forwards. works when system wakes from sleep, reconnects to Wi-Fi, or recovers from network interruptions. checks connectivity every 5 seconds by testing connection

relates: https://github.com/hcavarsan/kftray/issues/385