### PR TITLE
fix: AddConfigModal header Flex missing grow

### DIFF
--- a/frontend/src/components/AddConfigModal/index.tsx
+++ b/frontend/src/components/AddConfigModal/index.tsx
@@ -482,7 +482,7 @@ const AddConfigModal: React.FC<CustomConfigProps> = ({
             bg='#161616'
             borderBottom='1px solid rgba(255, 255, 255, 0.05)'
           >
-            <Flex justify='space-between' align='center'>
+            <Flex grow='1' justify='space-between' align='center'>
               <Text fontSize='sm' fontWeight='medium' color='gray.100'>
                 {isEdit ? 'Edit Configuration' : 'Add Configuration'}
               </Text>


### PR DESCRIPTION
# Pull Request

## Changes

- Fix layout issue in `AddConfigModal` caused by missing `grow='1'` in `Flex` within `Dialog.Header`

## Checklist before merging:
- [x] I have reviewed my own code.
- [x] I have tested the changes (if applicable).
- [x] I have updated the documentation (if applicable).
- [x] My changes do not break any existing functionalities.

## Screenshots

### Before

<img width="422" alt="image" src="https://github.com/user-attachments/assets/01256ff4-51bc-4cb1-92f2-94a520343bca" />


### After

<img width="426" alt="image" src="https://github.com/user-attachments/assets/0ad6cc3b-cbf4-4146-8530-c14dc41e1f93" />
