### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,8 +71,9 @@ jobs:
 
   rust-lint:
     name: Clippy
+    permissions:
+      contents: read
     strategy:
-      matrix:
         include:
           - os: ubuntu-24.04
             os_name: linux


### PR DESCRIPTION
Potential fix for [https://github.com/hcavarsan/kftray/security/code-scanning/10](https://github.com/hcavarsan/kftray/security/code-scanning/10)

To fix the issue, we will add a `permissions` block to the `Clippy` job (line 73) to explicitly define the minimal permissions required. Based on the tasks performed in the job, the `contents: read` permission should suffice. This change ensures that the `GITHUB_TOKEN` used in the job has only the necessary access, adhering to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
