### PR TITLE
refactor: add client caching and improve connection handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,8 +23,6 @@ node_modules
 *.sw?
 */target/*
 target/*
-target*/*
-target*
 frontend/dist/*
 !frontend/dist/.gitkeep
 crates/kftray-tauri/bin/*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2102,41 +2102,17 @@ dependencies = [
 
 [[package]]
 name = "headers"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "headers-core 0.2.0",
- "http 0.2.12",
- "httpdate",
- "mime",
- "sha1",
-]
-
-[[package]]
-name = "headers"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "headers-core 0.3.0",
+ "headers-core",
  "http 1.3.1",
  "httpdate",
  "mime",
  "sha1",
-]
-
-[[package]]
-name = "headers-core"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
-dependencies = [
- "http 0.2.12",
 ]
 
 [[package]]
@@ -2367,7 +2343,7 @@ checksum = "7ad4b0a1e37510028bc4ba81d0e38d239c39671b0f0ce9e02dfa93a8133f7c08"
 dependencies = [
  "bytes",
  "futures-util",
- "headers 0.4.1",
+ "headers",
  "http 1.3.1",
  "hyper 1.6.0",
  "hyper-rustls",
@@ -2395,24 +2371,6 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-proxy"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca815a891b24fdfb243fa3239c86154392b0953ee584aa1a2a1f66d20cbe75cc"
-dependencies = [
- "bytes",
- "futures",
- "headers 0.3.9",
- "http 0.2.12",
- "hyper 0.14.32",
- "hyper-tls 0.5.0",
- "native-tls",
- "tokio",
- "tokio-native-tls",
  "tower-service",
 ]
 
@@ -3102,7 +3060,6 @@ dependencies = [
  "httparse",
  "hyper 1.6.0",
  "hyper-openssl",
- "hyper-proxy",
  "hyper-util",
  "k8s-openapi",
  "kftray-commons",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,7 @@ http = "1.3"
 httparse = "1.10"
 hyper = { version = "1.6", features = ["client", "http1", "http2"] }
 hyper-openssl = "0.10"
-hyper-util = { version = "0.1", features = ["client-legacy", "http1", "tokio"] }
-hyper-proxy = "0.9.1"
+hyper-util = { version = "0.1", features = ["client-legacy", "http1", "tokio", "client", "client-proxy"] }
 insta = "1.43"
 k8s-openapi = { version = "0.25", default-features = false, features = [
   "latest",

--- a/crates/kftray-portforward/Cargo.toml
+++ b/crates/kftray-portforward/Cargo.toml
@@ -41,7 +41,6 @@ httparse = { workspace = true }
 hyper = { workspace = true }
 hyper-openssl = { workspace = true }
 hyper-util = { workspace = true }
-hyper-proxy = { workspace = true }
 k8s-openapi = { workspace = true }
 kftray-commons = { path = "../kftray-commons" }
 kftray-helper = { path = "../kftray-helper" }
@@ -74,4 +73,6 @@ tower-test = { workspace = true }
 tracing-subscriber = { workspace = true }
 
 [features]
-default = []
+default = ["http-proxy", "socks5"]
+http-proxy = []
+socks5 = []

--- a/crates/kftray-portforward/src/kube/client/builder.rs
+++ b/crates/kftray-portforward/src/kube/client/builder.rs
@@ -1,10 +1,22 @@
+use std::collections::HashMap;
 use std::env;
-use std::sync::Mutex;
+use std::sync::{
+    LazyLock,
+    Mutex,
+};
+use std::time::{
+    Duration,
+    Instant,
+};
 
 use anyhow::Result;
 use kube::config::Kubeconfig;
 use kube::Client;
-use log::info;
+use log::{
+    debug,
+    info,
+    warn,
+};
 
 use super::config::{
     create_config_with_context,
@@ -14,6 +26,81 @@ use super::config::{
 use super::connection::create_client_with_config;
 
 static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+struct ClientCacheKey {
+    kubeconfig_paths: Vec<String>,
+    context_name: String,
+}
+
+#[derive(Clone)]
+struct CachedClient {
+    client: Client,
+    created_at: Instant,
+}
+
+struct ClientCache {
+    cache: HashMap<ClientCacheKey, CachedClient>,
+    ttl: Duration,
+}
+
+impl ClientCache {
+    fn new() -> Self {
+        Self {
+            cache: HashMap::new(),
+            ttl: Duration::from_secs(300), // 5 minutes cache
+        }
+    }
+
+    fn get(&mut self, key: &ClientCacheKey) -> Option<Client> {
+        if let Some(cached) = self.cache.get(key) {
+            if cached.created_at.elapsed() < self.ttl {
+                debug!("Client cache hit for context: {}", key.context_name);
+                return Some(cached.client.clone());
+            } else {
+                debug!("Client cache expired for context: {}", key.context_name);
+                self.cache.remove(key);
+            }
+        }
+        None
+    }
+
+    fn insert(&mut self, key: ClientCacheKey, client: Client) {
+        debug!("Caching client for context: {}", key.context_name);
+        self.cache.insert(
+            key,
+            CachedClient {
+                client,
+                created_at: Instant::now(),
+            },
+        );
+    }
+
+    fn cleanup_expired(&mut self) {
+        let expired_keys: Vec<_> = self
+            .cache
+            .iter()
+            .filter_map(|(key, cached)| {
+                if cached.created_at.elapsed() >= self.ttl {
+                    Some(key.clone())
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        for key in expired_keys {
+            debug!(
+                "Removing expired client cache for context: {}",
+                key.context_name
+            );
+            self.cache.remove(&key);
+        }
+    }
+}
+
+static CLIENT_CACHE: LazyLock<Mutex<ClientCache>> =
+    LazyLock::new(|| Mutex::new(ClientCache::new()));
 
 pub async fn create_client_with_specific_context(
     kubeconfig: Option<String>, context_name: Option<&str>,
@@ -28,9 +115,29 @@ pub async fn create_client_with_specific_context(
     let (merged_kubeconfig, all_contexts, mut errors) = merge_kubeconfigs(&kubeconfig_paths)?;
 
     if let Some(context_name) = context_name {
+        let cache_key = ClientCacheKey {
+            kubeconfig_paths: kubeconfig_paths
+                .iter()
+                .map(|p| p.to_string_lossy().to_string())
+                .collect(),
+            context_name: context_name.to_string(),
+        };
+
+        if let Ok(mut cache) = CLIENT_CACHE.lock() {
+            cache.cleanup_expired();
+            if let Some(cached_client) = cache.get(&cache_key) {
+                info!("Using cached client for context: {context_name}");
+                return Ok((Some(cached_client), Some(merged_kubeconfig), all_contexts));
+            }
+        }
+
         match create_config_with_context(&merged_kubeconfig, context_name).await {
             Ok(config) => {
                 if let Some(client) = create_client_with_config(&config).await {
+                    if let Ok(mut cache) = CLIENT_CACHE.lock() {
+                        cache.insert(cache_key, client.clone());
+                    }
+                    info!("Created and cached new client for context: {context_name}");
                     return Ok((Some(client), Some(merged_kubeconfig), all_contexts));
                 } else {
                     errors.push(format!(
@@ -58,4 +165,29 @@ pub async fn create_client_with_specific_context(
             .collect::<Vec<_>>()
             .join("\n")
     ))
+}
+
+pub fn clear_client_cache() {
+    if let Ok(mut cache) = CLIENT_CACHE.lock() {
+        let count = cache.cache.len();
+        cache.cache.clear();
+        info!("Cleared {count} cached clients");
+    } else {
+        warn!("Failed to acquire lock for client cache clearing");
+    }
+}
+
+pub fn get_client_cache_stats() -> (usize, usize) {
+    if let Ok(mut cache) = CLIENT_CACHE.lock() {
+        cache.cleanup_expired();
+        let total = cache.cache.len();
+        let expired = cache
+            .cache
+            .iter()
+            .filter(|(_, cached)| cached.created_at.elapsed() >= cache.ttl)
+            .count();
+        (total, expired)
+    } else {
+        (0, 0)
+    }
 }

--- a/crates/kftray-portforward/src/kube/client/connection.rs
+++ b/crates/kftray-portforward/src/kube/client/connection.rs
@@ -1,5 +1,7 @@
 use std::future::Future;
 use std::pin::Pin;
+use std::sync::LazyLock;
+use std::time::Duration;
 
 use hyper_openssl::client::legacy::HttpsConnector;
 use hyper_util::client::legacy::connect::HttpConnector;
@@ -24,290 +26,259 @@ use super::error::{
     KubeClientError,
     KubeResult,
 };
+use super::proxy::{
+    create_insecure_with_proxy,
+    create_openssl_with_proxy,
+    create_rustls_with_proxy,
+};
 
 type StrategyFuture<'a> = Pin<Box<dyn Future<Output = KubeResult<Client>> + Send + 'a>>;
 type Strategy<'a> = (&'static str, StrategyFuture<'a>);
 
-async fn create_standard_client(config: &Config) -> KubeResult<Client> {
-    Client::try_from(config.clone()).map_err(|e| {
-        KubeClientError::connection_error_with_source("Failed to create standard kube client", e)
-    })
-}
+const CONNECTION_KEEPALIVE: Duration = Duration::from_secs(90);
+const POOL_IDLE_TIMEOUT: Duration = Duration::from_secs(300);
+const POOL_MAX_IDLE_PER_HOST: usize = 20;
+
+static HTTP_CONNECTOR: LazyLock<HttpConnector> = LazyLock::new(|| {
+    let mut connector = HttpConnector::new();
+    connector.set_keepalive(Some(CONNECTION_KEEPALIVE));
+    connector.set_nodelay(true);
+    connector.enforce_http(false);
+    connector
+});
 
 pub async fn create_client_with_config(config: &Config) -> Option<Client> {
-    if config.proxy_url.is_some() {
-        match create_standard_client(config).await {
-            Ok(client) => {
-                info!("Successfully connected using standard kube client with proxy");
-                return Some(client);
-            }
-            Err(e) => {
-                warn!("Standard client creation with proxy failed: {e}");
-            }
-        }
-    }
+    let strategies = if config.accept_invalid_certs {
+        info!("Creating insecure connection strategies for skip-tls-verify=true");
+        create_insecure_connection_strategies(config)
+    } else {
+        create_connection_strategies(config)
+    };
 
-    let config_with_invalid_certs_true = config.clone_with_invalid_certs(true);
-    let config_with_invalid_certs_false = config.clone_with_invalid_certs(false);
+    execute_strategies(strategies).await
+}
 
-    let strategies = create_strategies(
-        config,
-        config_with_invalid_certs_true,
-        config_with_invalid_certs_false,
-    );
-
+async fn execute_strategies(strategies: Vec<Strategy<'_>>) -> Option<Client> {
     let mut failed_attempts = Vec::new();
-    let mut last_error: Option<KubeClientError> = None;
+    let mut last_error = None;
 
     for (description, strategy) in strategies {
         info!("Attempting strategy: {description}");
-        match try_create_client(description, strategy).await {
+
+        let result = match strategy.await {
+            Ok(client) => test_client_connection(&client).await.map(|_| client),
+            Err(e) => Err(e),
+        };
+
+        match result {
             Ok(client) => {
                 info!("Successfully connected using: {description}");
                 return Some(client);
             }
-            Err(err) => {
-                warn!("Strategy '{description}' failed: {err}");
+            Err(e) => {
+                warn!("Strategy '{description}' failed: {e}");
                 failed_attempts.push(description.to_string());
-                last_error = Some(err);
+                last_error = Some(e);
             }
         }
     }
 
-    if !failed_attempts.is_empty() {
-        let strategy_error =
-            KubeClientError::strategy_failed("All connection strategies", failed_attempts.clone());
-
-        if let Some(last_err) = last_error {
-            error!(
-                "All connection strategies failed. Last error: {}. Attempted {} strategies: {}",
-                last_err,
-                failed_attempts.len(),
-                failed_attempts.join(", ")
-            );
-        } else {
-            error!("All connection strategies failed: {strategy_error}");
-        }
-    } else {
-        error!("No connection strategies available");
-    }
-
+    log_connection_failure(&failed_attempts, last_error);
     None
 }
 
-fn create_strategies<'a>(
-    original_config: &Config, config_with_invalid_certs_true: Config,
-    config_with_invalid_certs_false: Config,
-) -> Vec<Strategy<'a>> {
+fn create_connection_strategies(config: &Config) -> Vec<Strategy<'_>> {
+    let original = config.clone();
+    let without_invalid_certs = config.clone_with_invalid_certs(false);
+
     vec![
-        create_rustls_strategy(
-            "Rustls HTTPS connector (respecting kubeconfig settings)",
-            original_config.clone(),
-        ),
+        // Try with original settings first
+        create_rustls_strategy("Rustls (original settings)", original.clone()),
         create_openssl_strategy(
-            "OpenSSL HTTPS connector (respecting kubeconfig settings)",
-            original_config.clone(),
-            original_config.accept_invalid_certs,
+            "OpenSSL (original settings)",
+            original.clone(),
+            original.accept_invalid_certs,
         ),
+        // Try with explicit certificate verification
         create_openssl_strategy(
-            "OpenSSL HTTPS connector (with verification)",
-            config_with_invalid_certs_false.clone(),
+            "OpenSSL (with cert verification)",
+            without_invalid_certs,
             false,
-        ),
-        create_openssl_strategy(
-            "OpenSSL HTTPS connector (without verification)",
-            config_with_invalid_certs_true.clone(),
-            true,
-        ),
-        create_openssl_strategy(
-            "OpenSSL HTTPS connector (accept invalid certs and with verification)",
-            config_with_invalid_certs_true.clone(),
-            false,
-        ),
-        create_rustls_strategy(
-            "Rustls HTTPS connector (accept invalid certs)",
-            config_with_invalid_certs_true.clone(),
-        ),
-        create_rustls_strategy(
-            "Rustls HTTPS connector (do not accept invalid certs)",
-            config_with_invalid_certs_false.clone(),
-        ),
-        create_insecure_strategy(
-            "Insecure HTTP connector (do not accept invalid certs)",
-            config_with_invalid_certs_false,
-        ),
-        create_insecure_strategy(
-            "Insecure HTTP connector (accept invalid certs)",
-            config_with_invalid_certs_true,
         ),
     ]
 }
 
-fn create_rustls_strategy<'a>(description: &'static str, config: Config) -> Strategy<'a> {
+fn create_insecure_connection_strategies(config: &Config) -> Vec<Strategy<'_>> {
+    let original = config.clone();
+    let with_invalid_certs = config.clone_with_invalid_certs(true);
+
+    vec![
+        create_openssl_strategy(
+            "OpenSSL (skip cert verification)",
+            with_invalid_certs.clone(),
+            true,
+        ),
+        // Try with original settings
+        create_openssl_strategy(
+            "OpenSSL (original settings)",
+            original.clone(),
+            original.accept_invalid_certs,
+        ),
+        create_rustls_strategy("Rustls (original settings)", original),
+        create_insecure_strategy("Insecure HTTP", with_invalid_certs),
+    ]
+}
+
+fn create_rustls_strategy(description: &'static str, config: Config) -> Strategy<'static> {
     (
         description,
-        Box::pin(async move { create_rustls_https_connector(&config).await }),
+        Box::pin(async move { create_rustls_client(config).await }),
     )
 }
 
-fn create_openssl_strategy<'a>(
-    description: &'static str, config: Config, accept_invalid_certs: bool,
-) -> Strategy<'a> {
+fn create_openssl_strategy(
+    description: &'static str, config: Config, skip_verify: bool,
+) -> Strategy<'static> {
     (
         description,
-        Box::pin(async move {
-            let verify_mode = if accept_invalid_certs {
-                SslVerifyMode::NONE
-            } else {
-                SslVerifyMode::PEER
-            };
-            create_openssl_https_connector(&config, verify_mode).await
-        }),
+        Box::pin(async move { create_openssl_client(config, skip_verify).await }),
     )
 }
 
-fn create_insecure_strategy<'a>(description: &'static str, config: Config) -> Strategy<'a> {
+fn create_insecure_strategy(description: &'static str, config: Config) -> Strategy<'static> {
     (
         description,
-        Box::pin(async move { create_insecure_http_client(&config).await }),
+        Box::pin(async move { create_insecure_client(config).await }),
     )
 }
 
-async fn try_create_client(
-    description: &str, strategy: StrategyFuture<'_>,
-) -> Result<Client, KubeClientError> {
-    info!("Attempting to create client with {description}");
-    match strategy.await {
-        Ok(client) => match test_client(&client).await {
-            Ok(()) => {
-                info!("Successfully created client with {description}");
-                Ok(client)
-            }
-            Err(e) => {
-                warn!("{description} failed connection test: {e}");
-                Err(e)
-            }
-        },
-        Err(e) => {
-            warn!("Failed to create {description}: {e}");
-            Err(e)
-        }
+async fn create_rustls_client(config: Config) -> KubeResult<Client> {
+    if let Some(proxy_url) = config.proxy_url.clone() {
+        return create_rustls_with_proxy(config, &proxy_url).await;
     }
+
+    let connector = config.rustls_https_connector().map_err(|e| {
+        KubeClientError::connection_error_with_source("Failed to create Rustls connector", e)
+    })?;
+
+    let hyper_client =
+        hyper_util::client::legacy::Client::builder(TokioExecutor::new()).build(connector);
+    build_kube_client(config, hyper_client)
 }
 
-async fn create_openssl_https_connector(
-    config: &Config, verify_mode: SslVerifyMode,
-) -> KubeResult<Client> {
-    let ssl_method = SslMethod::tls();
-    let mut builder = SslConnector::builder(ssl_method).map_err(|e| {
+async fn create_openssl_client(config: Config, skip_verify: bool) -> KubeResult<Client> {
+    let ssl_connector = create_ssl_connector(skip_verify)?;
+    let http_connector = create_http_connector();
+
+    if let Some(proxy_url) = config.proxy_url.clone() {
+        return create_openssl_with_proxy(config, ssl_connector, http_connector, &proxy_url).await;
+    }
+
+    let https_connector =
+        HttpsConnector::with_connector(http_connector, ssl_connector).map_err(|e| {
+            KubeClientError::connection_error_with_source("Failed to create HTTPS connector", e)
+        })?;
+
+    let hyper_client = create_hyper_client(https_connector);
+    build_kube_client(config, hyper_client)
+}
+
+async fn create_insecure_client(config: Config) -> KubeResult<Client> {
+    let http_connector = create_http_connector();
+
+    if let Some(proxy_url) = config.proxy_url.clone() {
+        return create_insecure_with_proxy(config, http_connector, &proxy_url).await;
+    }
+
+    let hyper_client = create_hyper_client(http_connector);
+    build_kube_client(config, hyper_client)
+}
+
+fn create_ssl_connector(skip_verify: bool) -> KubeResult<openssl::ssl::SslConnectorBuilder> {
+    let mut builder = SslConnector::builder(SslMethod::tls()).map_err(|e| {
         KubeClientError::connection_error_with_source(
             "Failed to create SSL connector (ensure OpenSSL is properly configured)",
             e,
         )
     })?;
-    builder.set_verify(verify_mode);
-    let https_connector =
-        HttpsConnector::with_connector(HttpConnector::new(), builder).map_err(|e| {
-            KubeClientError::connection_error_with_source("Failed to create HTTPS connector", e)
-        })?;
 
-    let auth_layer = match config.auth_layer() {
-        Ok(Some(layer)) => Some(layer),
-        Ok(None) => {
-            warn!("No auth layer found for OpenSSL connector");
-            None
-        }
-        Err(e) => {
-            warn!("Failed to get auth layer (possible certificate validation issue): {e}");
-            return Err(KubeClientError::auth_error_with_source(
-                "Failed to get auth layer for OpenSSL connector",
-                e,
-            ));
-        }
-    };
+    builder.set_verify(if skip_verify {
+        SslVerifyMode::NONE
+    } else {
+        SslVerifyMode::PEER
+    });
 
-    let service = ServiceBuilder::new()
-        .layer(config.base_uri_layer())
-        .option_layer(auth_layer)
-        .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { Box::new(e) })
-        .service(
-            hyper_util::client::legacy::Client::builder(TokioExecutor::new())
-                .build(https_connector),
-        );
-
-    let client = Client::new(service, config.default_namespace.clone());
-    Ok(client)
+    Ok(builder)
 }
 
-async fn create_rustls_https_connector(config: &Config) -> KubeResult<Client> {
-    let https_connector = config.rustls_https_connector().map_err(|e| {
-        KubeClientError::connection_error_with_source("Failed to create Rustls HTTPS connector", e)
+pub fn create_http_connector() -> HttpConnector {
+    HTTP_CONNECTOR.clone()
+}
+
+pub fn create_hyper_client<C>(
+    connector: C,
+) -> hyper_util::client::legacy::Client<C, kube::client::Body>
+where
+    C: hyper_util::client::legacy::connect::Connect + Clone + Send + Sync + 'static,
+{
+    use hyper_util::rt::TokioTimer;
+
+    hyper_util::client::legacy::Client::builder(TokioExecutor::new())
+        .pool_idle_timeout(POOL_IDLE_TIMEOUT)
+        .pool_max_idle_per_host(POOL_MAX_IDLE_PER_HOST)
+        .retry_canceled_requests(true)
+        .timer(TokioTimer::new())
+        .build(connector)
+}
+
+async fn test_client_connection(client: &Client) -> KubeResult<()> {
+    client.apiserver_version().await.map_err(|e| {
+        KubeClientError::connection_error_with_source(
+            "Failed to connect to Kubernetes API server",
+            e,
+        )
     })?;
+    Ok(())
+}
 
-    let auth_layer = match config.auth_layer() {
-        Ok(Some(layer)) => Some(layer),
-        Ok(None) => {
-            warn!("No auth layer found for Rustls connector");
-            None
-        }
-        Err(e) => {
-            warn!("Failed to get auth layer (possible certificate validation issue): {e}");
-            return Err(KubeClientError::auth_error_with_source(
-                "Failed to get auth layer for Rustls connector",
-                e,
-            ));
-        }
-    };
+pub fn build_kube_client<C>(
+    config: Config, hyper_client: hyper_util::client::legacy::Client<C, kube::client::Body>,
+) -> KubeResult<Client>
+where
+    C: hyper_util::client::legacy::connect::Connect + Clone + Send + Sync + 'static,
+{
+    let auth_layer = config
+        .auth_layer()
+        .map_err(|e| KubeClientError::auth_error_with_source("Failed to create auth layer", e))?;
 
     let service = ServiceBuilder::new()
         .layer(config.base_uri_layer())
         .option_layer(auth_layer)
         .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { Box::new(e) })
-        .service(
-            hyper_util::client::legacy::Client::builder(TokioExecutor::new())
-                .build(https_connector),
-        );
+        .service(hyper_client);
 
-    let client = Client::new(service, config.default_namespace.clone());
-    Ok(client)
+    Ok(Client::new(service, config.default_namespace))
 }
 
-async fn create_insecure_http_client(config: &Config) -> KubeResult<Client> {
-    let http_connector = HttpConnector::new();
+fn log_connection_failure(failed_attempts: &[String], last_error: Option<KubeClientError>) {
+    if failed_attempts.is_empty() {
+        error!("No connection strategies available");
+        return;
+    }
 
-    let service = ServiceBuilder::new()
-        .layer(config.base_uri_layer())
-        .option_layer({
-            match config.auth_layer() {
-                Ok(layer) => layer,
-                Err(e) => {
-                    warn!("Failed to get auth layer for insecure client: {e}");
-                    None
-                }
-            }
-        })
-        .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { Box::new(e) })
-        .service(
-            hyper_util::client::legacy::Client::builder(TokioExecutor::new()).build(http_connector),
-        );
-
-    let client = Client::new(service, config.default_namespace.clone());
-    Ok(client)
-}
-
-async fn test_client(client: &Client) -> KubeResult<()> {
-    match client.apiserver_version().await {
-        Ok(version) => {
-            info!("Kubernetes API server version: {version:?}");
-            Ok(())
-        }
-        Err(e) => {
-            warn!("Failed to connect to Kubernetes API server: {e}");
-            Err(KubeClientError::connection_error_with_source(
-                "Failed to connect to Kubernetes API server. Possible causes: invalid certificates, unreachable server, authentication failure, or network connectivity issues",
-                e
-            ))
-        }
+    let strategies_list = failed_attempts.join(", ");
+    match last_error {
+        Some(err) => error!(
+            "All connection strategies failed. Last error: {}. Attempted {} strategies: {}",
+            err,
+            failed_attempts.len(),
+            strategies_list
+        ),
+        None => error!(
+            "All {} connection strategies failed: {}",
+            failed_attempts.len(),
+            strategies_list
+        ),
     }
 }
 
@@ -316,26 +287,60 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_create_strategies_ordering() {
-        let original_config = {
-            let mut config = Config::new("https://example.com".parse().unwrap());
-            config.accept_invalid_certs = true;
-            config
-        };
+    fn test_connection_strategies_count() {
+        let config = Config::new("https://example.com".parse().unwrap());
+        let strategies = create_connection_strategies(&config);
+        assert_eq!(strategies.len(), 3);
 
-        let config_true = original_config.clone_with_invalid_certs(true);
-        let config_false = original_config.clone_with_invalid_certs(false);
+        let mut insecure_config = Config::new("https://example.com".parse().unwrap());
+        insecure_config.accept_invalid_certs = true;
+        let insecure_strategies = create_insecure_connection_strategies(&insecure_config);
+        assert_eq!(insecure_strategies.len(), 4);
+    }
 
-        let strategies = create_strategies(&original_config, config_true, config_false);
+    #[test]
+    fn test_http_connector_configuration() {
+        let connector = create_http_connector();
+        drop(connector);
+    }
 
-        assert!(strategies.len() >= 2);
-        assert_eq!(
-            strategies[0].0,
-            "Rustls HTTPS connector (respecting kubeconfig settings)"
-        );
-        assert_eq!(
-            strategies[1].0,
-            "OpenSSL HTTPS connector (respecting kubeconfig settings)"
-        );
+    #[test]
+    fn test_ssl_connector_verify_modes() {
+        let connector_verify = create_ssl_connector(false);
+        assert!(connector_verify.is_ok());
+
+        let connector_no_verify = create_ssl_connector(true);
+        assert!(connector_no_verify.is_ok());
+    }
+
+    #[test]
+    fn test_proxy_url_parsing() {
+        let mut config = Config::new("https://example.com".parse().unwrap());
+        config.proxy_url = Some("http://proxy.example.com:8080".parse().unwrap());
+
+        assert!(config.proxy_url.is_some());
+        let proxy_url = config.proxy_url.as_ref().unwrap();
+        assert_eq!(proxy_url.scheme_str(), Some("http"));
+        assert_eq!(proxy_url.host(), Some("proxy.example.com"));
+        assert_eq!(proxy_url.port_u16(), Some(8080));
+    }
+
+    #[test]
+    fn test_socks5_proxy_url() {
+        let mut config = Config::new("https://example.com".parse().unwrap());
+        config.proxy_url = Some("socks5://localhost:1080".parse().unwrap());
+
+        assert!(config.proxy_url.is_some());
+        let proxy_url = config.proxy_url.as_ref().unwrap();
+        assert_eq!(proxy_url.scheme_str(), Some("socks5"));
+        assert_eq!(proxy_url.host(), Some("localhost"));
+        assert_eq!(proxy_url.port_u16(), Some(1080));
+    }
+
+    #[test]
+    fn test_error_creation() {
+        let error = KubeClientError::connection_error("Test connection error");
+        assert!(matches!(error, KubeClientError::ConnectionError { .. }));
+        assert_eq!(error.to_string(), "Connection error: Test connection error");
     }
 }

--- a/crates/kftray-portforward/src/kube/client/mod.rs
+++ b/crates/kftray-portforward/src/kube/client/mod.rs
@@ -2,6 +2,7 @@ pub mod builder;
 pub mod config;
 pub mod connection;
 pub mod error;
+pub mod proxy;
 pub mod utils;
 
 pub use builder::create_client_with_specific_context;

--- a/crates/kftray-portforward/src/kube/client/proxy.rs
+++ b/crates/kftray-portforward/src/kube/client/proxy.rs
@@ -1,0 +1,211 @@
+use hyper::Uri;
+use hyper_openssl::client::legacy::HttpsConnector;
+use hyper_util::client::legacy::connect::HttpConnector;
+use hyper_util::rt::TokioExecutor;
+use kube::client::ConfigExt;
+use kube::config::Config;
+use kube::Client;
+
+use super::connection::{
+    build_kube_client,
+    create_http_connector,
+    create_hyper_client,
+};
+use super::error::{
+    KubeClientError,
+    KubeResult,
+};
+
+pub async fn create_rustls_with_proxy(config: Config, proxy_url: &Uri) -> KubeResult<Client> {
+    match proxy_url.scheme_str() {
+        Some("http") | Some("https") => create_rustls_http_proxy(config, proxy_url).await,
+        Some("socks5") | Some("socks5h") => create_rustls_socks5_proxy(config, proxy_url).await,
+        _ => Err(KubeClientError::proxy_error(
+            format!("Unsupported proxy scheme: {:?}", proxy_url.scheme_str()),
+            proxy_url.to_string(),
+        )),
+    }
+}
+
+pub async fn create_openssl_with_proxy(
+    config: Config, ssl_builder: openssl::ssl::SslConnectorBuilder, http_connector: HttpConnector,
+    proxy_url: &Uri,
+) -> KubeResult<Client> {
+    match proxy_url.scheme_str() {
+        Some("http") | Some("https") => {
+            create_openssl_http_proxy(config, ssl_builder, http_connector, proxy_url).await
+        }
+        Some("socks5") | Some("socks5h") => {
+            create_openssl_socks5_proxy(config, ssl_builder, http_connector, proxy_url).await
+        }
+        _ => Err(KubeClientError::proxy_error(
+            format!("Unsupported proxy scheme: {:?}", proxy_url.scheme_str()),
+            proxy_url.to_string(),
+        )),
+    }
+}
+
+pub async fn create_insecure_with_proxy(
+    config: Config, http_connector: HttpConnector, proxy_url: &Uri,
+) -> KubeResult<Client> {
+    match proxy_url.scheme_str() {
+        Some("http") | Some("https") => {
+            create_insecure_http_proxy(config, http_connector, proxy_url).await
+        }
+        Some("socks5") | Some("socks5h") => {
+            create_insecure_socks5_proxy(config, http_connector, proxy_url).await
+        }
+        _ => Err(KubeClientError::proxy_error(
+            format!("Unsupported proxy scheme: {:?}", proxy_url.scheme_str()),
+            proxy_url.to_string(),
+        )),
+    }
+}
+
+async fn create_rustls_http_proxy(config: Config, proxy_url: &Uri) -> KubeResult<Client> {
+    validate_rustls_proxy_config(&config)?;
+
+    let tunnel = create_http_tunnel(proxy_url);
+    let connector = config
+        .rustls_https_connector_with_connector(tunnel)
+        .map_err(|e| {
+            KubeClientError::connection_error_with_source(
+                "Failed to create Rustls connector with HTTP proxy",
+                e,
+            )
+        })?;
+
+    let hyper_client =
+        hyper_util::client::legacy::Client::builder(TokioExecutor::new()).build(connector);
+    build_kube_client(config, hyper_client)
+}
+
+async fn create_rustls_socks5_proxy(config: Config, proxy_url: &Uri) -> KubeResult<Client> {
+    validate_rustls_proxy_config(&config)?;
+
+    let socks = create_socks5_proxy(proxy_url);
+    let connector = config
+        .rustls_https_connector_with_connector(socks)
+        .map_err(|e| {
+            KubeClientError::connection_error_with_source(
+                "Failed to create Rustls connector with SOCKS5 proxy",
+                e,
+            )
+        })?;
+
+    let hyper_client =
+        hyper_util::client::legacy::Client::builder(TokioExecutor::new()).build(connector);
+    build_kube_client(config, hyper_client)
+}
+
+async fn create_openssl_http_proxy(
+    config: Config, ssl_builder: openssl::ssl::SslConnectorBuilder, http_connector: HttpConnector,
+    proxy_url: &Uri,
+) -> KubeResult<Client> {
+    let tunnel = create_http_tunnel_with_connector(proxy_url, http_connector);
+    let connector = HttpsConnector::with_connector(tunnel, ssl_builder).map_err(|e| {
+        KubeClientError::connection_error_with_source(
+            "Failed to create OpenSSL connector with HTTP proxy",
+            e,
+        )
+    })?;
+
+    let hyper_client = create_hyper_client(connector);
+    build_kube_client(config, hyper_client)
+}
+
+async fn create_openssl_socks5_proxy(
+    config: Config, ssl_builder: openssl::ssl::SslConnectorBuilder, http_connector: HttpConnector,
+    proxy_url: &Uri,
+) -> KubeResult<Client> {
+    let socks = create_socks5_proxy_with_connector(proxy_url, http_connector);
+    let connector = HttpsConnector::with_connector(socks, ssl_builder).map_err(|e| {
+        KubeClientError::connection_error_with_source(
+            "Failed to create OpenSSL connector with SOCKS5 proxy",
+            e,
+        )
+    })?;
+
+    let hyper_client = create_hyper_client(connector);
+    build_kube_client(config, hyper_client)
+}
+
+async fn create_insecure_http_proxy(
+    config: Config, http_connector: HttpConnector, proxy_url: &Uri,
+) -> KubeResult<Client> {
+    let tunnel = create_http_tunnel_with_connector(proxy_url, http_connector);
+    let hyper_client = create_hyper_client(tunnel);
+    build_kube_client(config, hyper_client)
+}
+
+async fn create_insecure_socks5_proxy(
+    config: Config, http_connector: HttpConnector, proxy_url: &Uri,
+) -> KubeResult<Client> {
+    let socks = create_socks5_proxy_with_connector(proxy_url, http_connector);
+    let hyper_client = create_hyper_client(socks);
+    build_kube_client(config, hyper_client)
+}
+
+fn validate_rustls_proxy_config(config: &Config) -> KubeResult<()> {
+    if config.accept_invalid_certs {
+        return Err(KubeClientError::connection_error(
+            "Rustls with proxy and skip-tls-verify is not supported",
+        ));
+    }
+    Ok(())
+}
+
+fn create_http_tunnel(
+    proxy_url: &Uri,
+) -> hyper_util::client::legacy::connect::proxy::Tunnel<HttpConnector> {
+    use hyper_util::client::legacy::connect::proxy::Tunnel;
+    Tunnel::new(proxy_url.clone(), create_http_connector())
+}
+
+fn create_http_tunnel_with_connector(
+    proxy_url: &Uri, connector: HttpConnector,
+) -> hyper_util::client::legacy::connect::proxy::Tunnel<HttpConnector> {
+    use hyper_util::client::legacy::connect::proxy::Tunnel;
+    Tunnel::new(proxy_url.clone(), connector)
+}
+
+fn create_socks5_proxy(
+    proxy_url: &Uri,
+) -> hyper_util::client::legacy::connect::proxy::SocksV5<HttpConnector> {
+    use hyper_util::client::legacy::connect::proxy::SocksV5;
+    SocksV5::new(proxy_url.clone(), create_http_connector())
+}
+
+fn create_socks5_proxy_with_connector(
+    proxy_url: &Uri, connector: HttpConnector,
+) -> hyper_util::client::legacy::connect::proxy::SocksV5<HttpConnector> {
+    use hyper_util::client::legacy::connect::proxy::SocksV5;
+    SocksV5::new(proxy_url.clone(), connector)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_proxy_url_validation() {
+        let mut config = Config::new("https://example.com".parse().unwrap());
+        config.accept_invalid_certs = false;
+
+        assert!(validate_rustls_proxy_config(&config).is_ok());
+
+        config.accept_invalid_certs = true;
+        assert!(validate_rustls_proxy_config(&config).is_err());
+    }
+
+    #[test]
+    fn test_proxy_scheme_validation() {
+        let valid_schemes = ["http", "https", "socks5", "socks5h"];
+
+        for scheme in valid_schemes {
+            let url = format!("{scheme}://proxy.example.com:8080");
+            let uri: Uri = url.parse().unwrap();
+            assert!(uri.scheme_str().is_some());
+        }
+    }
+}

--- a/crates/kftray-portforward/src/kube/mod.rs
+++ b/crates/kftray-portforward/src/kube/mod.rs
@@ -6,6 +6,7 @@ mod proxy;
 mod service;
 mod start;
 mod stop;
+pub mod target_cache;
 pub mod tcp_forwarder;
 pub mod udp_forwarder;
 

--- a/crates/kftray-portforward/src/kube/models.rs
+++ b/crates/kftray-portforward/src/kube/models.rs
@@ -14,6 +14,8 @@ use serde::{
 use tokio::sync::Mutex;
 use tracing::debug;
 
+use super::target_cache::TargetCache;
+
 impl NameSpace {
     pub fn name_any(&self) -> String {
         self.0.clone().unwrap_or_else(|| "default".to_string())
@@ -131,7 +133,7 @@ pub struct PodInfo {
     pub labels_str: String,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 #[allow(dead_code)]
 pub struct PortForward {
     pub target: Target,
@@ -143,6 +145,7 @@ pub struct PortForward {
     pub config_id: i64,
     pub workload_type: String,
     pub connection: Arc<Mutex<Option<tokio::net::TcpStream>>>,
+    pub target_cache: Arc<TargetCache>,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/crates/kftray-portforward/src/kube/start.rs
+++ b/crates/kftray-portforward/src/kube/start.rs
@@ -358,8 +358,11 @@ pub async fn start_port_forward(
                             &config.service
                         );
 
-                        debug!("Port forwarding details: {port_forward:?}");
-                        debug!("Actual local port: {actual_local_port:?}");
+                        debug!(
+                            "Port forwarding established for config_id: {}",
+                            port_forward.config_id
+                        );
+                        debug!("Actual local port: {actual_local_port}");
 
                         let handle_key = format!(
                             "{}_{}",

--- a/crates/kftray-portforward/src/kube/target_cache.rs
+++ b/crates/kftray-portforward/src/kube/target_cache.rs
@@ -1,0 +1,396 @@
+use std::sync::Arc;
+use std::time::{
+    Duration,
+    Instant,
+};
+
+use dashmap::DashMap;
+use log::debug;
+
+use crate::kube::models::TargetPod;
+
+#[derive(Clone, Debug)]
+pub struct CacheConfig {
+    pub cache_ttl: Duration,
+    pub validation_interval: Duration,
+    pub max_entries: usize,
+}
+
+impl Default for CacheConfig {
+    fn default() -> Self {
+        Self {
+            cache_ttl: Duration::from_secs(3600),
+            validation_interval: Duration::from_secs(1800),
+            max_entries: 1000,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub struct TargetCacheKey {
+    pub selector: String,
+    pub namespace: String,
+    pub port: String,
+}
+
+impl TargetCacheKey {
+    pub fn from_target(target: &crate::kube::models::Target) -> Self {
+        let selector = match &target.selector {
+            crate::kube::models::TargetSelector::ServiceName(name) => format!("service:{name}"),
+            crate::kube::models::TargetSelector::PodLabel(label) => format!("label:{label}"),
+        };
+
+        let port = match &target.port {
+            crate::kube::models::Port::Number(num) => num.to_string(),
+            crate::kube::models::Port::Name(name) => name.clone(),
+        };
+
+        Self {
+            selector,
+            namespace: target.namespace.name_any(),
+            port,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CachedTarget {
+    pub target_pod: TargetPod,
+    pub cached_at: Instant,
+    pub last_validated_at: Instant,
+}
+
+impl CachedTarget {
+    pub fn new(target_pod: TargetPod) -> Self {
+        let now = Instant::now();
+        Self {
+            target_pod,
+            cached_at: now,
+            last_validated_at: now,
+        }
+    }
+
+    pub fn is_expired(&self, ttl: Duration) -> bool {
+        self.cached_at.elapsed() > ttl
+    }
+
+    pub fn needs_validation(&self, validation_interval: Duration) -> bool {
+        self.last_validated_at.elapsed() > validation_interval
+    }
+
+    pub fn mark_validated(&mut self) {
+        self.last_validated_at = Instant::now();
+    }
+}
+
+#[derive(Debug)]
+pub struct TargetCache {
+    cache: Arc<DashMap<TargetCacheKey, CachedTarget>>,
+    config: CacheConfig,
+}
+
+impl TargetCache {
+    pub fn new(config: CacheConfig) -> Self {
+        Self {
+            cache: Arc::new(DashMap::new()),
+            config,
+        }
+    }
+
+    pub fn get(&self, key: &TargetCacheKey) -> Option<TargetPod> {
+        if let Some(cached) = self.cache.get(key) {
+            if !cached.is_expired(self.config.cache_ttl) {
+                debug!("Cache hit for target {key:?}");
+                return Some(cached.target_pod.clone());
+            } else {
+                debug!("Cache entry expired for target {key:?}, performing lazy cleanup");
+                drop(cached);
+                self.cache.remove(key);
+            }
+        }
+        None
+    }
+
+    pub async fn get_with_validation<F, Fut>(
+        &self, key: &TargetCacheKey, validator: F,
+    ) -> Option<TargetPod>
+    where
+        F: FnOnce(TargetPod) -> Fut,
+        Fut: std::future::Future<Output = bool>,
+    {
+        debug!("Starting cache validation for key: {key:?}");
+
+        let cached_entry = self.cache.get(key);
+        if let Some(cached) = cached_entry {
+            debug!("Found cached entry for key: {key:?}");
+
+            if cached.is_expired(self.config.cache_ttl) {
+                debug!(
+                    "Cache entry is expired (older than {} seconds), removing",
+                    self.config.cache_ttl.as_secs()
+                );
+                drop(cached);
+                self.cache.remove(key);
+                return None;
+            }
+
+            let target_pod = cached.target_pod.clone();
+
+            if !cached.needs_validation(self.config.validation_interval) {
+                debug!(
+                    "Cache entry recently validated, using cached pod: {}",
+                    target_pod.pod_name
+                );
+                return Some(target_pod);
+            }
+
+            debug!(
+                "Cache entry needs validation (last validated {} seconds ago), validating pod: {}",
+                cached.last_validated_at.elapsed().as_secs(),
+                target_pod.pod_name
+            );
+
+            drop(cached);
+
+            let is_valid = validator(target_pod.clone()).await;
+            debug!(
+                "Validation result for pod {}: {}",
+                target_pod.pod_name, is_valid
+            );
+
+            if is_valid {
+                if let Some(mut cached) = self.cache.get_mut(key) {
+                    cached.mark_validated();
+                    debug!(
+                        "Updated validation timestamp for pod: {}",
+                        target_pod.pod_name
+                    );
+                }
+                return Some(target_pod);
+            } else {
+                debug!(
+                    "Cached pod {} failed validation, removing from cache to trigger refresh",
+                    target_pod.pod_name
+                );
+                self.cache.remove(key);
+                return None;
+            }
+        }
+
+        debug!("No cached entry found for key: {key:?}");
+        None
+    }
+
+    pub fn put(&self, key: TargetCacheKey, target_pod: TargetPod) {
+        debug!("Caching target pod for {key:?}");
+
+        if self.cache.len() >= self.config.max_entries {
+            self.evict_oldest_entries();
+        }
+
+        self.cache.insert(key, CachedTarget::new(target_pod));
+    }
+
+    fn evict_oldest_entries(&self) {
+        let entries_to_remove = (self.cache.len() / 4).max(1);
+
+        let mut oldest_entries: Vec<_> = self
+            .cache
+            .iter()
+            .map(|entry| (entry.key().clone(), entry.cached_at))
+            .collect();
+
+        oldest_entries.sort_by_key(|(_, cached_at)| *cached_at);
+
+        for (key, _) in oldest_entries.into_iter().take(entries_to_remove) {
+            self.cache.remove(&key);
+            debug!("Evicted old cache entry for {key:?}");
+        }
+    }
+
+    pub fn invalidate(&self, key: &TargetCacheKey) {
+        if self.cache.remove(key).is_some() {
+            debug!("Invalidated cache entry for {key:?}");
+        }
+    }
+
+    pub fn force_refresh(&self, key: &TargetCacheKey) {
+        if self.cache.remove(key).is_some() {
+            debug!("Forced refresh for cache entry {key:?}");
+        }
+    }
+
+    pub fn clear(&self) {
+        let count = self.cache.len();
+        self.cache.clear();
+        debug!("Cleared all {count} cache entries");
+    }
+
+    pub fn get_stats(&self) -> CacheStats {
+        let total_entries = self.cache.len();
+        let mut expired_entries = 0;
+        let mut needs_validation = 0;
+
+        for entry in self.cache.iter() {
+            if entry.is_expired(self.config.cache_ttl) {
+                expired_entries += 1;
+            } else if entry.needs_validation(self.config.validation_interval) {
+                needs_validation += 1;
+            }
+        }
+
+        CacheStats {
+            total_entries,
+            expired_entries,
+            valid_entries: total_entries - expired_entries,
+            needs_validation,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CacheStats {
+    pub total_entries: usize,
+    pub expired_entries: usize,
+    pub valid_entries: usize,
+    pub needs_validation: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kube::models::{
+        NameSpace,
+        Port,
+        Target,
+        TargetPod,
+        TargetSelector,
+    };
+
+    #[test]
+    fn test_cache_config_default() {
+        let config = CacheConfig::default();
+        assert_eq!(config.cache_ttl, Duration::from_secs(3600));
+        assert_eq!(config.validation_interval, Duration::from_secs(1800));
+        assert_eq!(config.max_entries, 1000);
+    }
+
+    #[test]
+    fn test_target_cache_key_from_target() {
+        let target = Target {
+            selector: TargetSelector::ServiceName("test-service".to_string()),
+            port: Port::Number(8080),
+            namespace: NameSpace(Some("default".to_string())),
+        };
+
+        let key = TargetCacheKey::from_target(&target);
+        assert_eq!(key.selector, "service:test-service");
+        assert_eq!(key.namespace, "default");
+        assert_eq!(key.port, "8080");
+
+        let target2 = Target {
+            selector: TargetSelector::PodLabel("app=web".to_string()),
+            port: Port::Name("http".to_string()),
+            namespace: NameSpace(None),
+        };
+
+        let key2 = TargetCacheKey::from_target(&target2);
+        assert_eq!(key2.selector, "label:app=web");
+        assert_eq!(key2.namespace, "default");
+        assert_eq!(key2.port, "http");
+    }
+
+    #[tokio::test]
+    async fn test_cached_target() {
+        let target_pod = TargetPod {
+            pod_name: "test-pod".to_string(),
+            port_number: 8080,
+        };
+
+        let cached = CachedTarget::new(target_pod.clone());
+        assert_eq!(cached.target_pod.pod_name, "test-pod");
+        assert_eq!(cached.target_pod.port_number, 8080);
+        assert!(!cached.is_expired(Duration::from_millis(100)));
+
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        assert!(cached.is_expired(Duration::from_millis(100)));
+    }
+
+    #[test]
+    fn test_cache_invalidation() {
+        let cache = TargetCache::new(CacheConfig::default());
+
+        let key = TargetCacheKey {
+            selector: "service:test".to_string(),
+            namespace: "default".to_string(),
+            port: "8080".to_string(),
+        };
+
+        let target_pod = TargetPod {
+            pod_name: "test-pod".to_string(),
+            port_number: 8080,
+        };
+
+        cache.put(key.clone(), target_pod);
+        assert!(cache.get(&key).is_some());
+
+        cache.invalidate(&key);
+        assert!(cache.get(&key).is_none());
+    }
+
+    #[test]
+    fn test_cache_stats() {
+        let cache = TargetCache::new(CacheConfig::default());
+        let stats = cache.get_stats();
+        assert_eq!(stats.total_entries, 0);
+        assert_eq!(stats.valid_entries, 0);
+        assert_eq!(stats.needs_validation, 0);
+    }
+
+    #[test]
+    fn test_force_refresh() {
+        let cache = TargetCache::new(CacheConfig::default());
+
+        let key = TargetCacheKey {
+            selector: "service:test".to_string(),
+            namespace: "default".to_string(),
+            port: "8080".to_string(),
+        };
+
+        let target_pod = TargetPod {
+            pod_name: "test-pod".to_string(),
+            port_number: 8080,
+        };
+
+        cache.put(key.clone(), target_pod);
+        assert!(cache.get(&key).is_some());
+
+        cache.force_refresh(&key);
+        assert!(cache.get(&key).is_none());
+    }
+
+    #[test]
+    fn test_clear_cache() {
+        let cache = TargetCache::new(CacheConfig::default());
+
+        for i in 0..5 {
+            let key = TargetCacheKey {
+                selector: format!("service:test-{i}"),
+                namespace: "default".to_string(),
+                port: "8080".to_string(),
+            };
+
+            let target_pod = TargetPod {
+                pod_name: format!("test-pod-{i}"),
+                port_number: 8080,
+            };
+
+            cache.put(key, target_pod);
+        }
+
+        assert_eq!(cache.get_stats().total_entries, 5);
+
+        cache.clear();
+        assert_eq!(cache.get_stats().total_entries, 0);
+    }
+}

--- a/crates/kftray-portforward/src/kube/target_cache.rs
+++ b/crates/kftray-portforward/src/kube/target_cache.rs
@@ -160,11 +160,13 @@ impl TargetCache {
 
             if is_valid {
                 if let Some(mut cached) = self.cache.get_mut(key) {
-                    cached.mark_validated();
-                    debug!(
-                        "Updated validation timestamp for pod: {}",
-                        target_pod.pod_name
-                    );
+                    if cached.target_pod.pod_name == target_pod.pod_name {
+                        cached.mark_validated();
+                        debug!(
+                            "Updated validation timestamp for pod: {}",
+                            target_pod.pod_name
+                        );
+                    }
                 }
                 return Some(target_pod);
             } else {

--- a/crates/kftray-portforward/src/kube/tests/portforward_tests.rs
+++ b/crates/kftray-portforward/src/kube/tests/portforward_tests.rs
@@ -28,6 +28,10 @@ use crate::kube::models::{
     TargetSelector,
 };
 use crate::kube::start::start_port_forward;
+use crate::kube::target_cache::{
+    CacheConfig,
+    TargetCache,
+};
 use crate::port_forward::CHILD_PROCESSES;
 
 struct KubernetesMocker {
@@ -201,6 +205,9 @@ async fn test_port_forward_tcp_success() -> Result<()> {
     let config = setup_test_config();
     let _configs = vec![config];
 
+    let cache_config = CacheConfig::default();
+    let target_cache = Arc::new(TargetCache::new(cache_config));
+
     let port_forward = PortForward {
         target,
         local_port: Some(0),
@@ -211,6 +218,7 @@ async fn test_port_forward_tcp_success() -> Result<()> {
         config_id: 1,
         workload_type: "service".to_string(),
         connection: Arc::new(tokio::sync::Mutex::new(None)),
+        target_cache,
     };
 
     let port_forward_task = tokio::spawn(async move {
@@ -297,6 +305,9 @@ async fn test_port_forward_udp_success() -> Result<()> {
     let mut config = setup_test_config();
     config.protocol = "udp".to_string();
 
+    let cache_config = CacheConfig::default();
+    let target_cache = Arc::new(TargetCache::new(cache_config));
+
     let port_forward = PortForward {
         target,
         local_port: Some(0),
@@ -307,6 +318,7 @@ async fn test_port_forward_udp_success() -> Result<()> {
         config_id: 1,
         workload_type: "service".to_string(),
         connection: Arc::new(tokio::sync::Mutex::new(None)),
+        target_cache,
     };
 
     let port_forward_task = tokio::spawn(async move {
@@ -423,6 +435,9 @@ async fn test_start_port_forward_mock_components() -> Result<()> {
         test_config.namespace.clone(),
     );
 
+    let cache_config = CacheConfig::default();
+    let target_cache = Arc::new(TargetCache::new(cache_config));
+
     let port_forward = PortForward {
         target,
         local_port: test_config.local_port,
@@ -433,6 +448,7 @@ async fn test_start_port_forward_mock_components() -> Result<()> {
         config_id: test_config.id.unwrap_or_default(),
         workload_type: test_config.workload_type.clone().unwrap_or_default(),
         connection: Arc::new(tokio::sync::Mutex::new(None)),
+        target_cache,
     };
 
     let http_log_state = Arc::new(HttpLogState::new());
@@ -534,6 +550,9 @@ async fn test_start_port_forward_mock_components_udp() -> Result<()> {
         test_config.namespace.clone(),
     );
 
+    let cache_config = CacheConfig::default();
+    let target_cache = Arc::new(TargetCache::new(cache_config));
+
     let port_forward = PortForward {
         target,
         local_port: test_config.local_port,
@@ -544,6 +563,7 @@ async fn test_start_port_forward_mock_components_udp() -> Result<()> {
         config_id: test_config.id.unwrap_or_default(),
         workload_type: test_config.workload_type.clone().unwrap_or_default(),
         connection: Arc::new(tokio::sync::Mutex::new(None)),
+        target_cache,
     };
 
     match port_forward.port_forward_udp().await {

--- a/crates/kftray-portforward/src/lib.rs
+++ b/crates/kftray-portforward/src/lib.rs
@@ -4,6 +4,7 @@ pub mod hostsfile;
 pub mod kube;
 pub mod network_utils;
 pub mod port_forward;
+pub mod port_forward_error;
 
 pub use kftray_http_logs::{
     HttpLogState,

--- a/crates/kftray-portforward/src/port_forward_error.rs
+++ b/crates/kftray-portforward/src/port_forward_error.rs
@@ -1,0 +1,262 @@
+use std::error::Error;
+use std::fmt;
+
+#[derive(Debug)]
+pub enum PortForwardError {
+    PodLookupFailed {
+        retry_count: usize,
+        last_error: String,
+        selector: String,
+    },
+    ClientDisconnected {
+        peer_addr: Option<String>,
+        stage: String,
+    },
+    StreamCreationFailed {
+        pod_name: String,
+        port: u16,
+        error: String,
+    },
+    NetworkError { message: String, recoverable: bool },
+    ConfigurationError { message: String },
+    ResourceExhausted {
+        resource_type: String,
+        current_usage: Option<usize>,
+        limit: Option<usize>,
+    },
+    TimeoutError {
+        operation: String,
+        timeout_duration: std::time::Duration,
+    },
+}
+
+impl fmt::Display for PortForwardError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PortForwardError::PodLookupFailed {
+                retry_count,
+                last_error,
+                selector,
+            } => write!(
+                f,
+                "Pod lookup failed for selector '{selector}' after {retry_count} retries: {last_error}"
+            ),
+            PortForwardError::ClientDisconnected { peer_addr, stage } => {
+                if let Some(addr) = peer_addr {
+                    write!(f, "Client {addr} disconnected during {stage}")
+                } else {
+                    write!(f, "Client disconnected during {stage}")
+                }
+            }
+            PortForwardError::StreamCreationFailed {
+                pod_name,
+                port,
+                error,
+            } => write!(
+                f,
+                "Failed to create stream to pod '{pod_name}' port {port}: {error}"
+            ),
+            PortForwardError::NetworkError {
+                message,
+                recoverable,
+            } => {
+                if *recoverable {
+                    write!(f, "Recoverable network error: {message}")
+                } else {
+                    write!(f, "Network error: {message}")
+                }
+            }
+            PortForwardError::ConfigurationError { message } => {
+                write!(f, "Configuration error: {message}")
+            }
+            PortForwardError::ResourceExhausted {
+                resource_type,
+                current_usage,
+                limit,
+            } => match (current_usage, limit) {
+                (Some(current), Some(max)) => write!(
+                    f,
+                    "Resource exhausted: {resource_type} ({current}/{max})"
+                ),
+                (Some(current), None) => {
+                    write!(f, "Resource exhausted: {resource_type} ({current})")
+                }
+                (None, Some(max)) => {
+                    write!(f, "Resource exhausted: {resource_type} (limit: {max})")
+                }
+                (None, None) => write!(f, "Resource exhausted: {resource_type}"),
+            },
+            PortForwardError::TimeoutError {
+                operation,
+                timeout_duration,
+            } => write!(
+                f,
+                "Operation '{operation}' timed out after {timeout_duration:?}"
+            ),
+        }
+    }
+}
+
+impl Error for PortForwardError {}
+
+impl PortForwardError {
+    pub fn pod_lookup_failed(
+        retry_count: usize, last_error: impl Into<String>, selector: impl Into<String>,
+    ) -> Self {
+        Self::PodLookupFailed {
+            retry_count,
+            last_error: last_error.into(),
+            selector: selector.into(),
+        }
+    }
+
+    pub fn client_disconnected(peer_addr: Option<String>, stage: impl Into<String>) -> Self {
+        Self::ClientDisconnected {
+            peer_addr,
+            stage: stage.into(),
+        }
+    }
+
+    pub fn stream_creation_failed(
+        pod_name: impl Into<String>, port: u16, error: impl Into<String>,
+    ) -> Self {
+        Self::StreamCreationFailed {
+            pod_name: pod_name.into(),
+            port,
+            error: error.into(),
+        }
+    }
+
+    pub fn recoverable_network_error(message: impl Into<String>) -> Self {
+        Self::NetworkError {
+            message: message.into(),
+            recoverable: true,
+        }
+    }
+
+    pub fn fatal_network_error(message: impl Into<String>) -> Self {
+        Self::NetworkError {
+            message: message.into(),
+            recoverable: false,
+        }
+    }
+
+    pub fn configuration_error(message: impl Into<String>) -> Self {
+        Self::ConfigurationError {
+            message: message.into(),
+        }
+    }
+
+    pub fn resource_exhausted(
+        resource_type: impl Into<String>, current_usage: Option<usize>, limit: Option<usize>,
+    ) -> Self {
+        Self::ResourceExhausted {
+            resource_type: resource_type.into(),
+            current_usage,
+            limit,
+        }
+    }
+
+    pub fn timeout_error(
+        operation: impl Into<String>, timeout_duration: std::time::Duration,
+    ) -> Self {
+        Self::TimeoutError {
+            operation: operation.into(),
+            timeout_duration,
+        }
+    }
+
+    pub fn is_recoverable(&self) -> bool {
+        match self {
+            PortForwardError::PodLookupFailed { .. } => true,
+            PortForwardError::ClientDisconnected { .. } => true,
+            PortForwardError::StreamCreationFailed { .. } => true,
+            PortForwardError::NetworkError { recoverable, .. } => *recoverable,
+            PortForwardError::ConfigurationError { .. } => false,
+            PortForwardError::ResourceExhausted { .. } => true,
+            PortForwardError::TimeoutError { .. } => true,
+        }
+    }
+
+    pub fn should_stop_server(&self) -> bool {
+        match self {
+            PortForwardError::ConfigurationError { .. } => true,
+            PortForwardError::NetworkError { recoverable, .. } => !recoverable,
+            _ => false,
+        }
+    }
+}
+
+pub type PortForwardResult<T> = Result<T, PortForwardError>;
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    #[test]
+    fn test_pod_lookup_failed() {
+        let error = PortForwardError::pod_lookup_failed(3, "Pod not found", "app=web");
+        assert!(error.is_recoverable());
+        assert!(!error.should_stop_server());
+        assert!(error.to_string().contains("app=web"));
+        assert!(error.to_string().contains("3 retries"));
+    }
+
+    #[test]
+    fn test_client_disconnected() {
+        let error = PortForwardError::client_disconnected(
+            Some("127.0.0.1:12345".to_string()),
+            "authentication",
+        );
+        assert!(error.is_recoverable());
+        assert!(!error.should_stop_server());
+        assert!(error.to_string().contains("127.0.0.1:12345"));
+        assert!(error.to_string().contains("authentication"));
+    }
+
+    #[test]
+    fn test_stream_creation_failed() {
+        let error =
+            PortForwardError::stream_creation_failed("test-pod", 8080, "Connection refused");
+        assert!(error.is_recoverable());
+        assert!(!error.should_stop_server());
+        assert!(error.to_string().contains("test-pod"));
+        assert!(error.to_string().contains("8080"));
+    }
+
+    #[test]
+    fn test_network_errors() {
+        let recoverable = PortForwardError::recoverable_network_error("Temporary DNS failure");
+        assert!(recoverable.is_recoverable());
+        assert!(!recoverable.should_stop_server());
+
+        let fatal = PortForwardError::fatal_network_error("Network interface down");
+        assert!(!fatal.is_recoverable());
+        assert!(fatal.should_stop_server());
+    }
+
+    #[test]
+    fn test_configuration_error() {
+        let error = PortForwardError::configuration_error("Invalid kubeconfig");
+        assert!(!error.is_recoverable());
+        assert!(error.should_stop_server());
+    }
+
+    #[test]
+    fn test_resource_exhausted() {
+        let error = PortForwardError::resource_exhausted("connections", Some(100), Some(100));
+        assert!(error.is_recoverable());
+        assert!(!error.should_stop_server());
+        assert!(error.to_string().contains("(100/100)"));
+    }
+
+    #[test]
+    fn test_timeout_error() {
+        let error = PortForwardError::timeout_error("pod lookup", Duration::from_secs(30));
+        assert!(error.is_recoverable());
+        assert!(!error.should_stop_server());
+        assert!(error.to_string().contains("30s"));
+    }
+}

--- a/crates/kftray-portforward/src/port_forward_error.rs
+++ b/crates/kftray-portforward/src/port_forward_error.rs
@@ -17,8 +17,13 @@ pub enum PortForwardError {
         port: u16,
         error: String,
     },
-    NetworkError { message: String, recoverable: bool },
-    ConfigurationError { message: String },
+    NetworkError {
+        message: String,
+        recoverable: bool,
+    },
+    ConfigurationError {
+        message: String,
+    },
     ResourceExhausted {
         resource_type: String,
         current_usage: Option<usize>,


### PR DESCRIPTION
- Add kubernetes client caching - Cache clients for 5 minutes to avoid recreating connections for the same context
- Add target selection caching - cache selected pods/services to avoid repeated prompts when reconnecting
- Improve connection reliability - Better retry logic and connection pooling for more stable connections
- Better proxy support - Improved proxy handling with dedicated module 