### PR TITLE
fix: move PATH cleanup after setup steps to fix pnpm install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,12 +198,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
 
-      - name: Clean up PATH on Windows
-        if: matrix.os == 'windows-latest'
-        uses: egor-tensin/cleanup-path@64ef0b5036b30ce7845058a1d7a8d0830db39b94
-        with:
-          dirs: 'C:\Program Files\CMake\bin;C:\Program Files\NASM'
-
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561
         with:
@@ -322,6 +316,42 @@ jobs:
           apple-team-id: 6M376JWU73
           app-path: crates/kftray-tauri/bin/kftray-helper-universal-apple-darwin
           entitlements-path: crates/kftray-helper/macos-helper-entitlements.plist
+
+      - name: Clean up PATH on Windows
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          # Get current PATH entries
+          $currentPath = $env:PATH -split ';'
+          $originalCount = $currentPath.Count
+
+          # Keep only essential paths (Windows, Rust, Node, CMake, NASM, Git)
+          $keepPatterns = @(
+            'Windows',
+            'system32',
+            'PowerShell',
+            'rustup',
+            'cargo',
+            'node',
+            'npm',
+            'pnpm',
+            'CMake',
+            'NASM',
+            'Git',
+            'OpenSSL'
+          )
+
+          $filteredPath = $currentPath | Where-Object {
+            $path = $_
+            foreach ($pattern in $keepPatterns) {
+              if ($path -match $pattern) { return $true }
+            }
+            return $false
+          }
+
+          $newPath = $filteredPath -join ';'
+          echo "PATH=$newPath" >> $env:GITHUB_ENV
+          Write-Host "Reduced PATH from $originalCount to $($filteredPath.Count) entries"
 
       - name: Build kftray-tauri Desktop App
         uses: tauri-apps/tauri-action@9ce1dcc1a78395184050946b71457a6c242beab6
@@ -443,12 +473,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
 
-      - name: Clean up PATH on Windows
-        if: matrix.os == 'windows-latest'
-        uses: egor-tensin/cleanup-path@64ef0b5036b30ce7845058a1d7a8d0830db39b94
-        with:
-          dirs: 'C:\Program Files\CMake\bin;C:\Program Files\NASM'
-
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561
         with:
@@ -527,6 +551,44 @@ jobs:
         run: |
           echo "PERL=$((where.exe perl)[0])" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
           echo "OPENSSL_SRC_PERL=$((where.exe perl)[0])" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
+      - name: Clean up PATH on Windows
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          # Get current PATH entries
+          $currentPath = $env:PATH -split ';'
+          $originalCount = $currentPath.Count
+
+          # Keep only essential paths (Windows, Rust, Node, CMake, NASM, Git, Perl)
+          $keepPatterns = @(
+            'Windows',
+            'system32',
+            'PowerShell',
+            'rustup',
+            'cargo',
+            'node',
+            'npm',
+            'pnpm',
+            'CMake',
+            'NASM',
+            'Git',
+            'OpenSSL',
+            'Strawberry',
+            'perl'
+          )
+
+          $filteredPath = $currentPath | Where-Object {
+            $path = $_
+            foreach ($pattern in $keepPatterns) {
+              if ($path -match $pattern) { return $true }
+            }
+            return $false
+          }
+
+          $newPath = $filteredPath -join ';'
+          echo "PATH=$newPath" >> $env:GITHUB_ENV
+          Write-Host "Reduced PATH from $originalCount to $($filteredPath.Count) entries"
 
       - name: Build kftui
         env:


### PR DESCRIPTION
## Summary

Fixes the pnpm install failure on Windows that was introduced in #535.

### Problem
The `cleanup-path` action was placed right after `checkout`, **before** Node.js/pnpm setup. This removed Node.js from PATH, causing pnpm install to fail with `cwd: undefined`.

### Solution
- Remove the `cleanup-path` action from its early position
- Add a PowerShell script that runs **after** all setup steps but **before** the build
- The script selectively keeps essential paths (Windows, Rust, Node, pnpm, CMake, NASM, Git, OpenSSL, Perl)
- Uses `GITHUB_ENV` to persist the cleaned PATH for subsequent steps

### Changes
- `kftray-tauri` job: PATH cleanup moved to right before "Build kftray-tauri Desktop App"
- `kftui` job: PATH cleanup moved to right before "Build kftui"

### Why PowerShell script instead of cleanup-path action?
1. More control over which paths to keep
2. Runs at the correct point in the workflow (after setup)
3. Logs the reduction for debugging

## Test plan
- [ ] Windows x86 build succeeds
- [ ] Windows x86_64 build succeeds  
- [ ] Windows arm64 build succeeds
- [ ] pnpm install completes without errors
- [ ] Linux/macOS builds unaffected