### PR TITLE
Potential fix for code scanning alert no. 34: Cleartext logging of sensitive information

### DIFF
--- a/crates/kftray-portforward/src/kube/proxy.rs
+++ b/crates/kftray-portforward/src/kube/proxy.rs
@@ -141,8 +141,6 @@ async fn process_single_proxy_config(
         .filter(|c: &char| c.is_alphanumeric())
         .collect();
 
-    info!("Cleaned username: {clean_username}");
-
     let protocol = config.protocol.to_string().to_lowercase();
 
     let hashed_name =


### PR DESCRIPTION
Potential fix for [https://github.com/hcavarsan/kftray/security/code-scanning/34](https://github.com/hcavarsan/kftray/security/code-scanning/34)

In general, to fix cleartext logging issues you either stop logging the sensitive value or replace it with a non-sensitive, redacted, or anonymized form. Encryption before logging can be used when you must retain the data but want to protect it at rest; however, that adds complexity and is unnecessary when the value is not strictly required in logs.

Here, the best fix with minimal behavioral impact is to avoid logging `clean_username` entirely, because the message is purely informational and not required for the proxy operation. We can simply remove the `info!("Cleaned username: {clean_username}");` line. No other code depends on this log line, and `clean_username` is still used later to construct `hashed_name`, so runtime behavior is unchanged except for the omission of this diagnostic log. No new imports or helper functions are necessary.

Concretely, in `crates/kftray-portforward/src/kube/proxy.rs`, remove line 144 containing the `info!` call, leaving the rest of the function intact.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
