### PR TITLE
ci: fix sbom-publish by including hidden files in artifact upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -784,6 +784,7 @@ jobs:
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: sbom-signed
+          include-hidden-files: true
           path: |
             sbom-kftray.cdx.json
             sbom-kftray.cdx.json.bundle.json


### PR DESCRIPTION
The VEX files (.vex.openvex.json and .vex.openvex.json.bundle.json) were not being uploaded because upload-artifact excludes hidden files by default. This caused sbom-publish to fail when trying to upload these missing files to the release.