### PR TITLE
chore(deps): migrate keyring and refresh dependency tree

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -34,7 +34,6 @@ jobs:
         uses: dtolnay/rust-toolchain@881ba7bf39a41cda34ac9e123fb41b44ed08232f
         with:
           toolchain: nightly
-          targets: x86_64-unknown-linux-musl
 
       - name: Install cargo-fuzz
         uses: taiki-e/install-action@v2
@@ -56,4 +55,4 @@ jobs:
       - name: Run fuzzer
         run: |
           cd fuzz
-          cargo +nightly fuzz run ${{ matrix.target }} -- -max_total_time=60
+          cargo +nightly fuzz run --target x86_64-unknown-linux-gnu ${{ matrix.target }} -- -max_total_time=60

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -34,6 +34,7 @@ jobs:
         uses: dtolnay/rust-toolchain@881ba7bf39a41cda34ac9e123fb41b44ed08232f
         with:
           toolchain: nightly
+          targets: x86_64-unknown-linux-musl
 
       - name: Install cargo-fuzz
         uses: taiki-e/install-action@v2

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -36,7 +36,9 @@ jobs:
           toolchain: nightly
 
       - name: Install cargo-fuzz
-        run: cargo +nightly install cargo-fuzz --version 0.13.1 --locked
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-fuzz@0.13.1
 
       - name: Cache cargo registry
         uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -36,7 +36,7 @@ jobs:
           toolchain: nightly
 
       - name: Install cargo-fuzz
-        run: cargo install cargo-fuzz --version 0.13.1 --locked
+        run: cargo +nightly install cargo-fuzz --version 0.13.1 --locked
 
       - name: Cache cargo registry
         uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,14 +9,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "ahash"
-version = "0.7.8"
+name = "aes"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
- "getrandom 0.2.17",
- "once_cell",
- "version_check",
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -61,23 +61,6 @@ name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
-
-[[package]]
-name = "android_log-sys"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84521a3cf562bc62942e294181d9eef17eb38ceb8c68677bc49f144e4c3d4f8d"
-
-[[package]]
-name = "android_logger"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb4e440d04be07da1f1bf44fb4495ebd58669372fe0cffa6e48595ac5bd88a3"
-dependencies = [
- "android_log-sys",
- "env_filter 0.1.4",
- "log",
-]
 
 [[package]]
 name = "android_system_properties"
@@ -145,6 +128,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "apple-native-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7be2f067ccd8d4b4d4a66ddafe0f32a5dff31732f32dbff85fefc40929b1f72"
+dependencies = [
+ "keyring-core",
+ "log",
+ "security-framework",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -173,12 +167,6 @@ dependencies = [
  "wl-clipboard-rs",
  "x11rb",
 ]
-
-[[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "asn1-rs"
@@ -572,6 +560,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -591,30 +588,6 @@ dependencies = [
  "futures-io",
  "futures-lite",
  "piper",
-]
-
-[[package]]
-name = "borsh"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
-dependencies = [
- "borsh-derive",
- "bytes",
- "cfg_aliases",
-]
-
-[[package]]
-name = "borsh-derive"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
-dependencies = [
- "once_cell",
- "proc-macro-crate 3.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -649,40 +622,6 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
-
-[[package]]
-name = "byte-unit"
-version = "5.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c6d47a4e2961fb8721bcfc54feae6455f2f64e7054f9bc67e875f0e77f4c58d"
-dependencies = [
- "rust_decimal",
- "schemars 1.2.1",
- "serde",
- "utf8-width",
-]
-
-[[package]]
-name = "bytecheck"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
-dependencies = [
- "bytecheck_derive",
- "ptr_meta",
- "simdutf8",
-]
-
-[[package]]
-name = "bytecheck_derive"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "bytemuck"
@@ -788,6 +727,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -870,6 +818,16 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common 0.1.7",
+ "inout",
 ]
 
 [[package]]
@@ -1348,6 +1306,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
 
 [[package]]
+name = "dbus"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dbus-secret-service"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
+dependencies = [
+ "aes",
+ "block-padding",
+ "cbc",
+ "dbus",
+ "fastrand",
+ "hkdf",
+ "num",
+ "once_cell",
+ "sha2",
+ "zeroize",
+]
+
+[[package]]
+name = "dbus-secret-service-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21d8f54da401bb5eb2a4d873ac4b359f4a599df2ca8634bb5b8c045e5ee78757"
+dependencies = [
+ "dbus-secret-service",
+ "keyring-core",
+]
+
+[[package]]
 name = "deltae"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1438,6 +1435,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common 0.1.7",
+ "subtle",
 ]
 
 [[package]]
@@ -1879,15 +1877,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fern"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4316185f709b23713e41e3195f90edef7fb00c3ed4adc79769cf09cc762a3b29"
-dependencies = [
- "log",
-]
-
-[[package]]
 name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1916,13 +1905,12 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.27"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+checksum = "2d5b2eef6fafbf69f877e55509ce5b11a760690ac9700a2921be067aa6afaef6"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox",
 ]
 
 [[package]]
@@ -1967,6 +1955,19 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "flexi_logger"
+version = "0.31.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aea7feddba9b4e83022270d49a58d4a1b3fdad04b34f78cf1ce471f698e42672"
+dependencies = [
+ "chrono",
+ "log",
+ "nu-ansi-term",
+ "regex",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2560,9 +2561,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash 0.7.8",
-]
 
 [[package]]
 name = "hashbrown"
@@ -2594,9 +2592,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
@@ -2630,6 +2628,24 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "home"
@@ -3010,7 +3026,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -3066,6 +3082,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
 ]
 
 [[package]]
@@ -3400,18 +3426,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "keyring"
-version = "3.6.3"
+name = "keyring-core"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+checksum = "fb1e621458ca9c51aa110bd0339d4751a056b9576bf1253aee1aa560dda0fc9d"
 dependencies = [
- "byteorder",
- "linux-keyutils",
  "log",
- "security-framework 2.11.1",
- "security-framework 3.7.0",
- "windows-sys 0.60.2",
- "zeroize",
 ]
 
 [[package]]
@@ -3424,7 +3444,6 @@ dependencies = [
  "git2",
  "lazy_static",
  "log",
- "portpicker",
  "serde",
  "serde_json",
  "sqlx",
@@ -3517,11 +3536,13 @@ name = "kftray-portforward"
 version = "0.27.28"
 dependencies = [
  "anyhow",
+ "apple-native-keyring-store",
  "async-trait",
  "base64 0.22.1",
  "bytes",
  "core-foundation 0.10.1",
  "dashmap",
+ "dbus-secret-service-keyring-store",
  "dirs",
  "env_logger",
  "flate2",
@@ -3534,7 +3555,7 @@ dependencies = [
  "hyper-util",
  "jiff",
  "k8s-openapi",
- "keyring",
+ "keyring-core",
  "kftray-commons",
  "kftray-helper",
  "kftray-http-logs",
@@ -3542,6 +3563,7 @@ dependencies = [
  "kube-runtime",
  "lazy_static",
  "libc",
+ "linux-keyutils-keyring-store",
  "log",
  "once_cell",
  "openssl",
@@ -3553,7 +3575,7 @@ dependencies = [
  "rustls-native-certs",
  "schannel",
  "secrecy",
- "security-framework 3.7.0",
+ "security-framework",
  "serde",
  "serde_json",
  "sha1 0.11.0",
@@ -3573,6 +3595,7 @@ dependencies = [
  "uuid",
  "whoami",
  "windows 0.62.2",
+ "windows-native-keyring-store",
 ]
 
 [[package]]
@@ -3626,10 +3649,11 @@ dependencies = [
  "dirs",
  "env_logger",
  "fix-path-env",
+ "flexi_logger",
  "inotify",
  "jiff",
  "k8s-openapi",
- "keyring",
+ "keyring-core",
  "kftray-commons",
  "kftray-helper",
  "kftray-mcp",
@@ -3656,7 +3680,6 @@ dependencies = [
  "tauri-plugin-fs",
  "tauri-plugin-global-shortcut",
  "tauri-plugin-http",
- "tauri-plugin-log",
  "tauri-plugin-notification",
  "tauri-plugin-os",
  "tauri-plugin-positioner",
@@ -3788,7 +3811,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c072737075826ee74d3e615e80334e41e617ca3d14fb46ef7cdfda822d6f15f2"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "async-broadcast",
  "async-stream",
  "backon",
@@ -3858,6 +3881,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "libgit2-sys"
 version = "0.18.4+1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3897,10 +3929,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags 2.11.1",
  "libc",
- "plain",
- "redox_syscall 0.7.5",
 ]
 
 [[package]]
@@ -3975,6 +4004,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-keyutils-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39fbed79f71dc21eb21d3d07c0e908a3c58ff9a1fdbf5cf44230fb3deb6d994b"
+dependencies = [
+ "keyring-core",
+ "linux-keyutils",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4006,9 +4045,6 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
-dependencies = [
- "value-bag",
-]
 
 [[package]]
 name = "lru"
@@ -4197,7 +4233,7 @@ dependencies = [
  "openssl-probe 0.2.1",
  "openssl-sys",
  "schannel",
- "security-framework 3.7.0",
+ "security-framework",
  "security-framework-sys",
  "tempfile",
 ]
@@ -4376,12 +4412,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
  "num-traits",
 ]
 
@@ -4419,6 +4478,28 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -4916,7 +4997,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link 0.2.1",
 ]
@@ -5177,12 +5258,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
-
-[[package]]
 name = "plist"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5190,7 +5265,7 @@ checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
- "quick-xml 0.39.3",
+ "quick-xml 0.39.4",
  "serde",
  "time",
 ]
@@ -5248,15 +5323,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
-]
-
-[[package]]
-name = "portpicker"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be97d76faf1bfab666e1375477b23fde79eccf0276e9b63b92a39d676a889ba9"
-dependencies = [
- "rand 0.8.6",
 ]
 
 [[package]]
@@ -5394,26 +5460,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
 
 [[package]]
-name = "ptr_meta"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
-dependencies = [
- "ptr_meta_derive",
-]
-
-[[package]]
-name = "ptr_meta_derive"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "publicsuffix"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5455,9 +5501,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.39.3"
+version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721da970c312655cde9b4ffe0547f20a8494866a4af5ff51f18b7c633d0c870b"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
 ]
@@ -5551,8 +5597,6 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
- "libc",
- "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
 
@@ -5562,7 +5606,7 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.5",
 ]
 
@@ -5575,16 +5619,6 @@ dependencies = [
  "chacha20",
  "getrandom 0.4.2",
  "rand_core 0.10.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -5745,15 +5779,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
-dependencies = [
- "bitflags 2.11.1",
-]
-
-[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5812,15 +5837,6 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
-
-[[package]]
-name = "rend"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
-dependencies = [
- "bytecheck",
-]
 
 [[package]]
 name = "reqwest"
@@ -5951,52 +5967,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rkyv"
-version = "0.7.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
-dependencies = [
- "bitvec",
- "bytecheck",
- "bytes",
- "hashbrown 0.12.3",
- "ptr_meta",
- "rend",
- "rkyv_derive",
- "seahash",
- "tinyvec",
- "uuid",
-]
-
-[[package]]
-name = "rkyv_derive"
-version = "0.7.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "rust_decimal"
-version = "1.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c5108e3d4d903e21aac27f12ba5377b6b34f9f44b325e4894c7924169d06995"
-dependencies = [
- "arrayvec",
- "borsh",
- "bytes",
- "num-traits",
- "rand 0.8.6",
- "rkyv",
- "serde",
- "serde_json",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6058,7 +6028,7 @@ dependencies = [
  "openssl-probe 0.2.1",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.7.0",
+ "security-framework",
 ]
 
 [[package]]
@@ -6086,7 +6056,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki",
- "security-framework 3.7.0",
+ "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
@@ -6198,31 +6168,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "seahash"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
-
-[[package]]
 name = "secrecy"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
 dependencies = [
  "zeroize",
-]
-
-[[package]]
-name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags 2.11.1",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
 ]
 
 [[package]]
@@ -6698,7 +6649,7 @@ dependencies = [
  "objc2-foundation",
  "objc2-quartz-core",
  "raw-window-handle",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "tracing",
  "wasm-bindgen",
  "web-sys",
@@ -7353,28 +7304,6 @@ dependencies = [
  "tokio",
  "url",
  "urlpattern",
-]
-
-[[package]]
-name = "tauri-plugin-log"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7545bd67f070a4500432c826e2e0682146a1d6712aee22a2786490156b574d93"
-dependencies = [
- "android_logger",
- "byte-unit",
- "fern",
- "log",
- "objc2",
- "objc2-foundation",
- "serde",
- "serde_json",
- "serde_repr",
- "swift-rs",
- "tauri",
- "tauri-plugin",
- "thiserror 2.0.18",
- "time",
 ]
 
 [[package]]
@@ -8484,12 +8413,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
-name = "utf8-width"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1292c0d970b54115d14f2492fe0170adf21d68a1de108eebc51c1df4f346a091"
-
-[[package]]
 name = "utf8-zero"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8525,12 +8448,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "value-bag"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
 
 [[package]]
 name = "vcpkg"
@@ -8808,7 +8725,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
 dependencies = [
  "proc-macro2",
- "quick-xml 0.39.3",
+ "quick-xml 0.39.4",
  "quote",
 ]
 
@@ -9227,6 +9144,19 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-native-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5fd986f648459dd29aa252ed3a5ad11a60c0b1251bf81625fb03a86c69d274e"
+dependencies = [
+ "byteorder",
+ "keyring-core",
+ "regex",
+ "windows-sys 0.61.2",
+ "zeroize",
+]
 
 [[package]]
 name = "windows-numerics"
@@ -9958,6 +9888,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,29 +5,30 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.dependencies]
-anyhow = "1.0.100"
+anyhow = "1.0.102"
 async-trait = "0.1.89"
 base64 = "0.22"
 bb8 = "0.9.1"
 brotli = "8.0.2"
 built = "0.8"
 bytes = "1.11"
-chrono = { version = "0.4.43", features = ["serde"] }
-clap = { version = "4.5.54", features = ["derive"] }
+chrono = { version = "0.4.44", features = ["serde"] }
+clap = { version = "4.6.1", features = ["derive"] }
 crossterm = { version = "0.29", optional = false }
 dashmap = "6.1"
 dirs = "6.0"
 env_logger = "0.11"
 fix-path-env = { git = "https://github.com/tauri-apps/fix-path-env-rs" }
+flexi_logger = "0.31"
 flate2 = "1.1"
 futures = "0.3"
 git2 = { version = "0.20", features = ["ssh"] }
 http = "1.4"
 http-body-util = "0.1"
 httparse = "1.10"
-hyper = { version = "1.8.1", features = ["client", "http1", "http2", "server"] }
+hyper = { version = "1.9.0", features = ["client", "http1", "http2", "server"] }
 hyper-openssl = { version = "0.10", features = ["client-legacy"] }
-hyper-util = { version = "0.1.19", features = [
+hyper-util = { version = "0.1.20", features = [
   "client",
   "client-legacy",
   "client-proxy",
@@ -35,15 +36,15 @@ hyper-util = { version = "0.1.19", features = [
   "server",
   "tokio",
 ] }
-insta = "1.46"
-k8s-openapi = { version = "0.27.0", default-features = false, features = [
+insta = "1.47"
+k8s-openapi = { version = "0.27.1", default-features = false, features = [
   "latest",
 ] }
-keyring = { version = "3.6", features = [
-  "apple-native",
-  "linux-native",
-  "windows-native",
-] }
+keyring-core = "1.0"
+apple-native-keyring-store = { version = "1.0", features = ["keychain"] }
+dbus-secret-service-keyring-store = { version = "1.0", features = ["crypto-rust"] }
+linux-keyutils-keyring-store = "1.0"
+windows-native-keyring-store = "1.0"
 kftray-commons = { version = "0.27.28", path = "crates/kftray-commons" }
 kftray-helper = { version = "0.27.28", path = "crates/kftray-helper" }
 kftray-http-logs = { version = "0.27.28", path = "crates/kftray-http-logs" }
@@ -51,7 +52,7 @@ kftray-mcp = { version = "0.27.28", path = "crates/kftray-mcp" }
 kftray-network-monitor = { version = "0.27.28", path = "crates/kftray-network-monitor" }
 kftray-portforward = { version = "0.27.28", path = "crates/kftray-portforward" }
 kftray-shortcuts = { version = "0.27.28", path = "crates/kftray-shortcuts" }
-kube = { version = "3.0.0", features = [
+kube = { version = "3.1.0", features = [
   "client",
   "config",
   "http-proxy",
@@ -61,10 +62,10 @@ kube = { version = "3.0.0", features = [
   "rustls-tls",
   "ws",
 ] }
-kube-core = "3.0"
-kube-runtime = { version = "3.0.0", features = ["unstable-runtime"] }
+kube-core = "3.1"
+kube-runtime = { version = "3.1.0", features = ["unstable-runtime"] }
 lazy_static = "1.5"
-libc = "0.2.180"
+libc = "0.2.186"
 log = "0.4"
 mockall = "0.14"
 netstat2 = "0.11.2"
@@ -73,12 +74,11 @@ open = "5.3"
 openssl = { version = "0.10", features = ["vendored"] }
 openssl-sys = { version = "0.9", features = ["vendored"] }
 pem = "3.0"
-portpicker = "0.1"
 rand = "0.10"
 ratatui = { version = "0.30.0", features = ["unstable-widget-ref"] }
 ratatui-explorer = { branch = "master", git = "https://github.com/hcavarsan/ratatui-explorer" }
 rcgen = "0.14"
-reqwest = "0.13.1"
+reqwest = "0.13.3"
 rustls = { version = "0.23", default-features = false, features = [
   "ring",
   "std",
@@ -86,18 +86,18 @@ rustls = { version = "0.23", default-features = false, features = [
 ] }
 rustls-native-certs = "0.8.3"
 secrecy = "0.10"
-semver = "1.0.27"
+semver = "1.0.28"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 sha1 = "0.11"
-socket2 = "0.6.1"
+socket2 = "0.6.3"
 sqlx = { version = "0.8", default-features = false, features = [
   "runtime-tokio-native-tls",
   "sqlite",
 ] }
 sysinfo = "0.39.0"
-tar = "0.4.44"
-tauri = { version = "2.9.5", default-features = false, features = [
+tar = "0.4.45"
+tauri = { version = "2.11.1", default-features = false, features = [
   "devtools",
   "image-ico",
   "image-png",
@@ -105,24 +105,23 @@ tauri = { version = "2.9.5", default-features = false, features = [
   "tray-icon",
   "wry",
 ] }
-tauri-build = { version = "2.5.3", features = [] }
+tauri-build = { version = "2.6.1", features = [] }
 tauri-plugin-clipboard-manager = "2.3.2"
-tauri-plugin-dialog = "2.6.0"
-tauri-plugin-fs = "2.4.5"
+tauri-plugin-dialog = "2.7.1"
+tauri-plugin-fs = "2.5.1"
 tauri-plugin-global-shortcut = "2.3.1"
-tauri-plugin-http = "2.5.6"
-tauri-plugin-log = "2"
+tauri-plugin-http = "2.5.9"
 tauri-plugin-notification = "2.3.3"
 tauri-plugin-os = "2.3.2"
 tauri-plugin-positioner = { version = "2.3.1", features = ["tray-icon"] }
 tauri-plugin-process = "2.3.1"
-tauri-plugin-shell = "2.3.4"
-tauri-plugin-updater = "2.9.0"
-tempfile = "3.24.0"
+tauri-plugin-shell = "2.3.5"
+tauri-plugin-updater = "2.10.1"
+tempfile = "3.27.0"
 thiserror = "2.0.18"
 throbber-widgets-tui = "0.11.0"
 time = "0.3"
-tokio = { version = "1.49.0", features = [
+tokio = { version = "1.52.3", features = [
   "fs",
   "io-util",
   "macros",
@@ -142,12 +141,12 @@ tokio-util = { version = "0.7.18", features = ["rt"] }
 tower = { version = "0.5", features = ["util"] }
 tower-test = "0.4"
 tracing = "0.1"
-tracing-subscriber = { version = "0.3.22", features = ["env-filter", "fmt"] }
+tracing-subscriber = { version = "0.3.23", features = ["env-filter", "fmt"] }
 tui-logger = "0.18"
 tungstenite = { version = "0.29.0", features = ["native-tls"] }
 url = "2.5.8"
-uuid = { version = "1.19.0", features = ["v4"] }
-whoami = "2.0.2"
+uuid = { version = "1.23.1", features = ["v4"] }
+whoami = "2.1.2"
 windows = { version = "0.62", features = [
   "Win32_Foundation",
   "Win32_Security",

--- a/crates/kftray-commons/Cargo.toml
+++ b/crates/kftray-commons/Cargo.toml
@@ -19,7 +19,6 @@ futures = { workspace = true }
 git2 = { workspace = true }
 lazy_static = { workspace = true }
 log = { workspace = true }
-portpicker = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sqlx = { workspace = true }

--- a/crates/kftray-commons/src/utils/config.rs
+++ b/crates/kftray-commons/src/utils/config.rs
@@ -3,7 +3,6 @@ use log::{
     error,
     info,
 };
-use portpicker::pick_unused_port;
 use serde_json::json;
 use sqlx::{
     Row,
@@ -670,6 +669,13 @@ pub async fn clean_all_custom_hosts_entries_with_mode(mode: DatabaseMode) -> Res
     clean_all_custom_hosts_entries_with_pool(&context.pool).await
 }
 
+fn pick_unused_local_port() -> Option<u16> {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .ok()
+        .and_then(|l| l.local_addr().ok())
+        .map(|a| a.port())
+}
+
 fn prepare_config(mut config: Config) -> Config {
     if let Some(ref mut alias) = config.alias {
         *alias = alias.trim().to_string();
@@ -679,7 +685,7 @@ fn prepare_config(mut config: Config) -> Config {
     }
 
     if config.local_port == Some(0) || config.local_port.is_none() {
-        match pick_unused_port() {
+        match pick_unused_local_port() {
             Some(port) => config.local_port = Some(port),
             None => {
                 config.local_port = config.remote_port;

--- a/crates/kftray-commons/src/utils/config.rs
+++ b/crates/kftray-commons/src/utils/config.rs
@@ -670,10 +670,24 @@ pub async fn clean_all_custom_hosts_entries_with_mode(mode: DatabaseMode) -> Res
 }
 
 fn pick_unused_local_port() -> Option<u16> {
-    std::net::TcpListener::bind("127.0.0.1:0")
-        .ok()
-        .and_then(|l| l.local_addr().ok())
-        .map(|a| a.port())
+    use std::net::{
+        TcpListener,
+        UdpSocket,
+    };
+
+    for _ in 0..10 {
+        let Ok(tcp) = TcpListener::bind("127.0.0.1:0") else {
+            continue;
+        };
+        let Ok(addr) = tcp.local_addr() else {
+            continue;
+        };
+        let port = addr.port();
+        if UdpSocket::bind(("127.0.0.1", port)).is_ok() {
+            return Some(port);
+        }
+    }
+    None
 }
 
 fn prepare_config(mut config: Config) -> Config {

--- a/crates/kftray-portforward/Cargo.toml
+++ b/crates/kftray-portforward/Cargo.toml
@@ -44,7 +44,7 @@ hyper-openssl = { workspace = true }
 hyper-util = { workspace = true }
 jiff = { version = "0.2", features = ["serde"] }
 k8s-openapi = { workspace = true }
-keyring = { workspace = true }
+keyring-core = { workspace = true }
 kftray-commons = { workspace = true }
 kftray-helper = { workspace = true }
 kftray-http-logs = { workspace = true }
@@ -85,12 +85,18 @@ tower-test = { workspace = true }
 tracing-subscriber = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-security-framework = "3.5.1"
+security-framework = "3.7.0"
 core-foundation = "0.10.1"
+apple-native-keyring-store = { workspace = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+dbus-secret-service-keyring-store = { workspace = true }
+linux-keyutils-keyring-store = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-schannel = "0.1.28"
+schannel = "0.1.29"
 windows = { workspace = true }
+windows-native-keyring-store = { workspace = true }
 
 [features]
 default = ["http-proxy", "socks5"]

--- a/crates/kftray-portforward/src/ssl/cert_generator.rs
+++ b/crates/kftray-portforward/src/ssl/cert_generator.rs
@@ -5,7 +5,7 @@ use anyhow::{
     Context,
     Result,
 };
-use keyring::Entry;
+use keyring_core::Entry;
 use log::{
     info,
     warn,

--- a/crates/kftray-portforward/src/ssl/cert_store.rs
+++ b/crates/kftray-portforward/src/ssl/cert_store.rs
@@ -8,7 +8,7 @@ use anyhow::{
     Result,
 };
 use base64::Engine;
-use keyring::Entry;
+use keyring_core::Entry;
 use lazy_static::lazy_static;
 use log::{
     debug,

--- a/crates/kftray-portforward/src/ssl/composite_store.rs
+++ b/crates/kftray-portforward/src/ssl/composite_store.rs
@@ -26,19 +26,19 @@ impl LinuxCompositeStore {
     pub fn new() -> Result<Arc<CredentialStore>> {
         let primary: Arc<CredentialStore> = dbus_secret_service_keyring_store::Store::new()
             .map_err(|e| Error::PlatformFailure(Box::new(e)))?;
-        let fallback: Option<Arc<CredentialStore>> =
-            match linux_keyutils_keyring_store::Store::new() {
-                Ok(store) => {
-                    let store: Arc<CredentialStore> = store;
-                    Some(store)
-                }
-                Err(e) => {
-                    log::warn!(
-                        "keyutils fallback unavailable: {e}; legacy keyutils credentials will not be migrated"
-                    );
-                    None
-                }
-            };
+        let fallback: Option<Arc<CredentialStore>> = match linux_keyutils_keyring_store::Store::new(
+        ) {
+            Ok(store) => {
+                let store: Arc<CredentialStore> = store;
+                Some(store)
+            }
+            Err(e) => {
+                log::warn!(
+                    "keyutils fallback unavailable: {e}; legacy keyutils credentials will not be migrated"
+                );
+                None
+            }
+        };
         Ok(Arc::new(Self { primary, fallback }))
     }
 }

--- a/crates/kftray-portforward/src/ssl/composite_store.rs
+++ b/crates/kftray-portforward/src/ssl/composite_store.rs
@@ -24,17 +24,21 @@ pub struct LinuxCompositeStore {
 
 impl LinuxCompositeStore {
     pub fn new() -> Result<Arc<CredentialStore>> {
-        let primary = dbus_secret_service_keyring_store::Store::new()
+        let primary: Arc<CredentialStore> = dbus_secret_service_keyring_store::Store::new()
             .map_err(|e| Error::PlatformFailure(Box::new(e)))?;
-        let fallback = match linux_keyutils_keyring_store::Store::new() {
-            Ok(store) => Some(store),
-            Err(e) => {
-                log::warn!(
-                    "keyutils fallback unavailable: {e}; legacy keyutils credentials will not be migrated"
-                );
-                None
-            }
-        };
+        let fallback: Option<Arc<CredentialStore>> =
+            match linux_keyutils_keyring_store::Store::new() {
+                Ok(store) => {
+                    let store: Arc<CredentialStore> = store;
+                    Some(store)
+                }
+                Err(e) => {
+                    log::warn!(
+                        "keyutils fallback unavailable: {e}; legacy keyutils credentials will not be migrated"
+                    );
+                    None
+                }
+            };
         Ok(Arc::new(Self { primary, fallback }))
     }
 }

--- a/crates/kftray-portforward/src/ssl/composite_store.rs
+++ b/crates/kftray-portforward/src/ssl/composite_store.rs
@@ -1,0 +1,137 @@
+#![cfg(target_os = "linux")]
+
+use std::any::Any;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use keyring_core::api::{
+    CredentialApi,
+    CredentialStoreApi,
+};
+use keyring_core::{
+    Credential,
+    CredentialPersistence,
+    CredentialStore,
+    Entry,
+    Error,
+    Result,
+};
+
+pub struct LinuxCompositeStore {
+    primary: Arc<CredentialStore>,
+    fallback: Arc<CredentialStore>,
+}
+
+impl LinuxCompositeStore {
+    pub fn new() -> Result<Arc<CredentialStore>> {
+        let primary = dbus_secret_service_keyring_store::Store::new()
+            .map_err(|e| Error::PlatformFailure(Box::new(e)))?;
+        let fallback = linux_keyutils_keyring_store::Store::new()
+            .map_err(|e| Error::PlatformFailure(Box::new(e)))?;
+        Ok(Arc::new(Self { primary, fallback }))
+    }
+}
+
+impl CredentialStoreApi for LinuxCompositeStore {
+    fn vendor(&self) -> String {
+        "kftray-linux-composite (dbus-secret-service primary, keyutils fallback)".into()
+    }
+
+    fn id(&self) -> String {
+        "kftray-linux-composite".into()
+    }
+
+    fn persistence(&self) -> CredentialPersistence {
+        self.primary.persistence()
+    }
+
+    fn build(
+        &self, service: &str, user: &str, modifiers: Option<&HashMap<&str, &str>>,
+    ) -> Result<Entry> {
+        let primary = self.primary.build(service, user, modifiers)?;
+        let fallback = self.fallback.build(service, user, modifiers).ok();
+        let cred: Arc<Credential> = Arc::new(CompositeCredential { primary, fallback });
+        Ok(Entry::new_with_credential(cred))
+    }
+
+    fn search(&self, spec: &HashMap<&str, &str>) -> Result<Vec<Entry>> {
+        self.primary.search(spec)
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+struct CompositeCredential {
+    primary: Entry,
+    fallback: Option<Entry>,
+}
+
+impl CredentialApi for CompositeCredential {
+    fn set_secret(&self, secret: &[u8]) -> Result<()> {
+        self.primary.set_secret(secret)
+    }
+
+    fn get_secret(&self) -> Result<Vec<u8>> {
+        match self.primary.get_secret() {
+            Err(Error::NoEntry) => self.read_fallback_bytes(),
+            other => other,
+        }
+    }
+
+    fn set_password(&self, password: &str) -> Result<()> {
+        self.primary.set_password(password)
+    }
+
+    fn get_password(&self) -> Result<String> {
+        match self.primary.get_password() {
+            Err(Error::NoEntry) => self.read_fallback_string(),
+            other => other,
+        }
+    }
+
+    fn delete_credential(&self) -> Result<()> {
+        let primary_result = self.primary.delete_credential();
+        if let Some(f) = &self.fallback {
+            let _ = f.delete_credential();
+        }
+        primary_result
+    }
+
+    fn get_credential(&self) -> Result<Option<Arc<Credential>>> {
+        Ok(None)
+    }
+
+    fn get_specifiers(&self) -> Option<(String, String)> {
+        self.primary.get_specifiers()
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+impl CompositeCredential {
+    fn read_fallback_string(&self) -> Result<String> {
+        let Some(f) = &self.fallback else {
+            return Err(Error::NoEntry);
+        };
+        let value = f.get_password()?;
+        if let Err(e) = self.primary.set_password(&value) {
+            log::warn!("keyring migration: copy keyutils → secret-service failed: {e}");
+        }
+        Ok(value)
+    }
+
+    fn read_fallback_bytes(&self) -> Result<Vec<u8>> {
+        let Some(f) = &self.fallback else {
+            return Err(Error::NoEntry);
+        };
+        let value = f.get_secret()?;
+        if let Err(e) = self.primary.set_secret(&value) {
+            log::warn!("keyring migration: copy keyutils → secret-service failed: {e}");
+        }
+        Ok(value)
+    }
+}

--- a/crates/kftray-portforward/src/ssl/composite_store.rs
+++ b/crates/kftray-portforward/src/ssl/composite_store.rs
@@ -19,15 +19,22 @@ use keyring_core::{
 
 pub struct LinuxCompositeStore {
     primary: Arc<CredentialStore>,
-    fallback: Arc<CredentialStore>,
+    fallback: Option<Arc<CredentialStore>>,
 }
 
 impl LinuxCompositeStore {
     pub fn new() -> Result<Arc<CredentialStore>> {
         let primary = dbus_secret_service_keyring_store::Store::new()
             .map_err(|e| Error::PlatformFailure(Box::new(e)))?;
-        let fallback = linux_keyutils_keyring_store::Store::new()
-            .map_err(|e| Error::PlatformFailure(Box::new(e)))?;
+        let fallback = match linux_keyutils_keyring_store::Store::new() {
+            Ok(store) => Some(store),
+            Err(e) => {
+                log::warn!(
+                    "keyutils fallback unavailable: {e}; legacy keyutils credentials will not be migrated"
+                );
+                None
+            }
+        };
         Ok(Arc::new(Self { primary, fallback }))
     }
 }
@@ -49,7 +56,10 @@ impl CredentialStoreApi for LinuxCompositeStore {
         &self, service: &str, user: &str, modifiers: Option<&HashMap<&str, &str>>,
     ) -> Result<Entry> {
         let primary = self.primary.build(service, user, modifiers)?;
-        let fallback = self.fallback.build(service, user, modifiers).ok();
+        let fallback = self
+            .fallback
+            .as_ref()
+            .and_then(|f| f.build(service, user, modifiers).ok());
         let cred: Arc<Credential> = Arc::new(CompositeCredential { primary, fallback });
         Ok(Entry::new_with_credential(cred))
     }
@@ -93,10 +103,12 @@ impl CredentialApi for CompositeCredential {
 
     fn delete_credential(&self) -> Result<()> {
         let primary_result = self.primary.delete_credential();
-        if let Some(f) = &self.fallback {
-            let _ = f.delete_credential();
+        let fallback_result = self.fallback.as_ref().map(|f| f.delete_credential());
+        match (primary_result, fallback_result) {
+            (Ok(()), _) => Ok(()),
+            (Err(Error::NoEntry), Some(Ok(()))) => Ok(()),
+            (Err(e), _) => Err(e),
         }
-        primary_result
     }
 
     fn get_credential(&self) -> Result<Option<Arc<Credential>>> {

--- a/crates/kftray-portforward/src/ssl/keyring_init.rs
+++ b/crates/kftray-portforward/src/ssl/keyring_init.rs
@@ -1,0 +1,41 @@
+use std::sync::Once;
+
+#[cfg(target_os = "linux")]
+use crate::ssl::composite_store::LinuxCompositeStore;
+
+static INSTALL: Once = Once::new();
+
+pub fn install_default_keyring_store() {
+    INSTALL.call_once(|| {
+        if let Err(e) = try_install() {
+            log::error!("failed to install default keyring store: {e}");
+        }
+    });
+}
+
+fn try_install() -> anyhow::Result<()> {
+    if std::env::var("KFTRAY_TEST_MODE").is_ok() {
+        keyring_core::set_default_store(keyring_core::mock::Store::new()?);
+        return Ok(());
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let store = apple_native_keyring_store::keychain::Store::new()?;
+        keyring_core::set_default_store(store);
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        let store = LinuxCompositeStore::new()?;
+        keyring_core::set_default_store(store);
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        let store = windows_native_keyring_store::Store::new()?;
+        keyring_core::set_default_store(store);
+    }
+
+    Ok(())
+}

--- a/crates/kftray-portforward/src/ssl/keyring_init.rs
+++ b/crates/kftray-portforward/src/ssl/keyring_init.rs
@@ -37,5 +37,11 @@ fn try_install() -> anyhow::Result<()> {
         keyring_core::set_default_store(store);
     }
 
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+    {
+        anyhow::bail!("no native keyring store implementation available for this target");
+    }
+
+    #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
     Ok(())
 }

--- a/crates/kftray-portforward/src/ssl/mod.rs
+++ b/crates/kftray-portforward/src/ssl/mod.rs
@@ -1,6 +1,9 @@
 pub mod cert_generator;
 pub mod cert_manager;
 pub mod cert_store;
+#[cfg(target_os = "linux")]
+pub mod composite_store;
+pub mod keyring_init;
 pub mod platform;
 
 use std::sync::Once;
@@ -26,3 +29,4 @@ pub use cert_manager::{
     CertificateManager,
 };
 pub use cert_store::CertificateStore;
+pub use keyring_init::install_default_keyring_store;

--- a/crates/kftray-server/Cargo.toml
+++ b/crates/kftray-server/Cargo.toml
@@ -11,21 +11,21 @@ license = "GPL-3.0"
 [dependencies]
 async-trait = "0.1.89"
 bytes = "1.11"
-env_logger = "0.11.8"
+env_logger = "0.11.10"
 futures = "0.3"
 http = "1.4"
 http-body-util = "0.1"
-hyper = { version = "1.8.1", features = ["full"] }
+hyper = { version = "1.9.0", features = ["full"] }
 hyper-util = { version = "0.1", features = ["full"] }
 log = "0.4.29"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-socket2 = "0.6.1"
-tokio = { version = "1.49.0", features = ["full", "macros", "rt-multi-thread"] }
+socket2 = "0.6.3"
+tokio = { version = "1.52.3", features = ["full", "macros", "rt-multi-thread"] }
 tokio-tungstenite = { version = "0.29.0", features = ["rustls-tls-webpki-roots"] }
 tungstenite = "0.29.0"
 url = "2.5.8"
-uuid = { version = "1.19", features = ["v4"] }
+uuid = { version = "1.23", features = ["v4"] }
 
 [dev-dependencies]
 lazy_static = "1.5.0"

--- a/crates/kftray-shortcuts/Cargo.toml
+++ b/crates/kftray-shortcuts/Cargo.toml
@@ -22,7 +22,7 @@ tokio = { workspace = true, features = ["sync"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 evdev = "0.13.2"
-mio = { version = "1.1.1", features = ["os-ext"] }
+mio = { version = "1.2.0", features = ["os-ext"] }
 
 [features]
 default = []

--- a/crates/kftray-tauri/Cargo.toml
+++ b/crates/kftray-tauri/Cargo.toml
@@ -22,9 +22,10 @@ async-trait = { workspace = true }
 dirs = { workspace = true }
 env_logger = { workspace = true }
 fix-path-env = { workspace = true }
+flexi_logger = { workspace = true }
 jiff = "0.2"
 k8s-openapi = { workspace = true }
-keyring = { workspace = true }
+keyring-core = { workspace = true }
 kftray-commons = { workspace = true }
 kftray-helper = { workspace = true }
 kftray-mcp = { workspace = true }
@@ -46,7 +47,6 @@ tauri-plugin-dialog = { workspace = true }
 tauri-plugin-fs = { workspace = true }
 tauri-plugin-global-shortcut = { workspace = true }
 tauri-plugin-http = { workspace = true }
-tauri-plugin-log = { workspace = true }
 tauri-plugin-notification = { workspace = true }
 tauri-plugin-os = { workspace = true }
 tauri-plugin-positioner = { workspace = true }
@@ -67,7 +67,7 @@ kftray-helper = { workspace = true }
 tauri-build = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-inotify = "0.11.0"
+inotify = "0.11.1"
 ksni = "0.3"
 libc = { workspace = true }
 png = "0.17"

--- a/crates/kftray-tauri/capabilities/migrated.json
+++ b/crates/kftray-tauri/capabilities/migrated.json
@@ -94,7 +94,6 @@
     "notification:allow-request-permission",
     "notification:allow-show",
     "positioner:default",
-    "updater:default",
-    "log:default"
+    "updater:default"
   ]
 }

--- a/crates/kftray-tauri/src/commands/github.rs
+++ b/crates/kftray-tauri/src/commands/github.rs
@@ -1,4 +1,4 @@
-use keyring::{
+use keyring_core::{
     Entry,
     Error as KeyringError,
 };
@@ -90,106 +90,37 @@ pub async fn import_configs_from_github(
 
 #[cfg(test)]
 mod tests {
-    use std::any::Any;
-    use std::collections::BTreeMap;
     use std::sync::{
-        Arc,
         Mutex,
-    };
-
-    use keyring::credential::{
-        CredentialApi,
-        CredentialBuilderApi,
-        CredentialPersistence,
+        MutexGuard,
     };
 
     use super::*;
 
-    type SharedStore = Arc<Mutex<BTreeMap<String, String>>>;
+    static KEYRING_TEST_LOCK: Mutex<()> = Mutex::new(());
 
-    struct MockEntry {
-        handle: String,
-        store: SharedStore,
-    }
-
-    impl CredentialApi for MockEntry {
-        fn set_password(&self, password: &str) -> keyring::Result<()> {
-            self.store
-                .lock()
-                .unwrap()
-                .insert(self.handle.clone(), password.into());
-            Ok(())
-        }
-
-        fn set_secret(&self, _secret: &[u8]) -> keyring::Result<()> {
-            Err(keyring::Error::NoEntry)
-        }
-
-        fn get_password(&self) -> keyring::Result<String> {
-            match self.store.lock().unwrap().get(&self.handle) {
-                Some(secret) => Ok(secret.clone()),
-                None => Err(keyring::Error::NoEntry),
-            }
-        }
-
-        fn get_secret(&self) -> keyring::Result<Vec<u8>> {
-            Err(keyring::Error::NoEntry)
-        }
-
-        fn delete_credential(&self) -> keyring::Result<()> {
-            self.store.lock().unwrap().remove(&self.handle);
-            Ok(())
-        }
-
-        fn as_any(&self) -> &dyn Any {
-            self
-        }
-    }
-
-    struct MockCredentialBuilder {
-        store: SharedStore,
-    }
-
-    impl CredentialBuilderApi for MockCredentialBuilder {
-        fn build(
-            &self, _target: Option<&str>, service: &str, user: &str,
-        ) -> keyring::Result<Box<keyring::Credential>> {
-            let credential = MockEntry {
-                handle: format!("{service}:{user}"),
-                store: self.store.clone(),
-            };
-            Ok(Box::new(credential))
-        }
-
-        fn as_any(&self) -> &dyn Any {
-            self
-        }
-
-        fn persistence(&self) -> CredentialPersistence {
-            CredentialPersistence::ProcessOnly
-        }
-    }
-
-    fn use_mock_keyring() {
-        let store = SharedStore::default();
-        keyring::set_default_credential_builder(Box::new(MockCredentialBuilder { store }));
+    fn use_mock_keyring() -> MutexGuard<'static, ()> {
+        let guard = KEYRING_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        keyring_core::set_default_store(keyring_core::mock::Store::new().unwrap());
+        guard
     }
 
     #[test]
     fn test_keyring_operations() {
-        use_mock_keyring();
+        let _guard = use_mock_keyring();
 
         let entry = Entry::new("test_service", "test_name").unwrap();
         assert!(entry.set_password("test_password").is_ok());
         assert_eq!(entry.get_password().unwrap(), "test_password");
         assert!(entry.delete_credential().is_ok());
-        // After delete, get_password should return NoEntry
-        assert!(entry.get_password().is_err());
+        assert!(matches!(entry.get_password(), Err(KeyringError::NoEntry)));
     }
 
     #[test]
     fn test_store_get_delete_key() {
-        use_mock_keyring();
+        let _guard = use_mock_keyring();
 
         let result = store_key("test_service", "test_name", "test_password");
         assert!(result.is_ok());

--- a/crates/kftray-tauri/src/main.rs
+++ b/crates/kftray-tauri/src/main.rs
@@ -42,11 +42,46 @@ use crate::tray::{
     handle_window_event,
 };
 
+fn init_file_logger() -> anyhow::Result<()> {
+    use kftray_commons::utils::config_dir::get_app_log_path;
+
+    let log_path = get_app_log_path().map_err(|e| anyhow::anyhow!(e))?;
+    let log_dir = log_path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("log path has no parent directory"))?
+        .to_path_buf();
+    let basename = format!(
+        "kftray_{}",
+        jiff::Zoned::now().strftime("%Y-%m-%d_%H-%M-%S")
+    );
+
+    flexi_logger::Logger::try_with_str("info")?
+        .log_to_file(
+            flexi_logger::FileSpec::default()
+                .directory(log_dir)
+                .basename(basename),
+        )
+        .duplicate_to_stdout(flexi_logger::Duplicate::Info)
+        .rotate(
+            flexi_logger::Criterion::Size(5_000_000),
+            flexi_logger::Naming::Numbers,
+            flexi_logger::Cleanup::KeepLogFiles(1),
+        )
+        .format(flexi_logger::detailed_format)
+        .start()?;
+
+    Ok(())
+}
+
 fn main() {
     // CRITICAL: Must be called before ANY other code that might touch X11.
     // This prevents crashes with "[xcb] Most likely this is a multi-threaded
     // client and XInitThreads has not been called" on Linux X11 systems.
     x11_init::init_x11_threads();
+
+    if let Err(e) = init_file_logger() {
+        eprintln!("failed to initialize file logger: {e}");
+    }
 
     if let Err(e) = fix_path_env::fix_all_vars() {
         log::warn!("fix_path_env::fix_all_vars failed: {e}");
@@ -59,6 +94,7 @@ fn main() {
         unsafe { std::env::set_var("HOME", home) };
     }
 
+    kftray_portforward::ssl::install_default_keyring_store();
     kftray_portforward::ssl::ensure_crypto_provider_installed();
 
     let positioning_active = Arc::new(AtomicBool::new(false));
@@ -267,26 +303,7 @@ fn main() {
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_http::init())
-        .plugin(tauri_plugin_notification::init())
-        .plugin({
-            let log_filename = format!(
-                "kftray_{}",
-                jiff::Zoned::now().strftime("%Y-%m-%d_%H-%M-%S")
-            );
-            tauri_plugin_log::Builder::new()
-                .targets([
-                    tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::Stdout),
-                    tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::Webview),
-                    tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::LogDir {
-                        file_name: Some(log_filename),
-                    }),
-                ])
-                .level(log::LevelFilter::Info)
-                .timezone_strategy(tauri_plugin_log::TimezoneStrategy::UseLocal)
-                .max_file_size(5_000_000)
-                .rotation_strategy(tauri_plugin_log::RotationStrategy::KeepOne)
-                .build()
-        });
+        .plugin(tauri_plugin_notification::init());
 
     let app = app
         .plugin(tauri_plugin_os::init())

--- a/crates/kftui/Cargo.toml
+++ b/crates/kftui/Cargo.toml
@@ -53,7 +53,7 @@ built = { workspace = true }
 reqwest = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
-reqwest = { version = "0.13.1", default-features = false, features = [
+reqwest = { version = "0.13.3", default-features = false, features = [
   "native-tls",
   "http2",
   "charset",

--- a/crates/kftui/src/main.rs
+++ b/crates/kftui/src/main.rs
@@ -24,6 +24,7 @@ use crate::logging::{
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    kftray_portforward::ssl::install_default_keyring_store();
     kftray_portforward::ssl::ensure_crypto_provider_installed();
 
     let cli = Cli::parse();

--- a/frontend/knip.json
+++ b/frontend/knip.json
@@ -3,5 +3,5 @@
   "entry": ["src/logs.tsx"],
   "project": ["src/**/*.{ts,tsx}!"],
   "ignoreBinaries": ["taze"],
-  "ignoreDependencies": ["@codecov/vite-plugin", "@eslint/js", "@eslint/eslintrc", "@tauri-apps/plugin-log"]
+  "ignoreDependencies": ["@codecov/vite-plugin", "@eslint/js", "@eslint/eslintrc"]
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,7 +37,6 @@
     "@tauri-apps/cli": "2.10.1",
     "@tauri-apps/plugin-dialog": "~2.7.0",
     "@tauri-apps/plugin-fs": "~2.5.0",
-    "@tauri-apps/plugin-log": "~2.8.0",
     "@tauri-apps/plugin-shell": "~2.3.5",
     "@types/node": "^25.5.0",
     "@types/react": "^19.2.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,9 +85,6 @@ importers:
       '@tauri-apps/plugin-fs':
         specifier: ~2.5.0
         version: 2.5.0
-      '@tauri-apps/plugin-log':
-        specifier: ~2.8.0
-        version: 2.8.0
       '@tauri-apps/plugin-shell':
         specifier: ~2.3.5
         version: 2.3.5
@@ -925,9 +922,6 @@ packages:
 
   '@tauri-apps/plugin-fs@2.5.0':
     resolution: {integrity: sha512-c83kbz61AK+rKjhS+je9+stIO27nXj7p9cqeg36TwkIUtxpCFTttlHHtqon6h6FN54cXjyAjlMPOJcW3mwE5XQ==}
-
-  '@tauri-apps/plugin-log@2.8.0':
-    resolution: {integrity: sha512-a+7rOq3MJwpTOLLKbL8d0qGZ85hgHw5pNOWusA9o3cf7cEgtYHiGY/+O8fj8MvywQIGqFv0da2bYQDlrqLE7rw==}
 
   '@tauri-apps/plugin-shell@2.3.5':
     resolution: {integrity: sha512-jewtULhiQ7lI7+owCKAjc8tYLJr92U16bPOeAa472LHJdgaibLP83NcfAF2e+wkEcA53FxKQAZ7byDzs2eeizg==}
@@ -3631,10 +3625,6 @@ snapshots:
       '@tauri-apps/api': 2.10.1
 
   '@tauri-apps/plugin-fs@2.5.0':
-    dependencies:
-      '@tauri-apps/api': 2.10.1
-
-  '@tauri-apps/plugin-log@2.8.0':
     dependencies:
       '@tauri-apps/api': 2.10.1
 


### PR DESCRIPTION
Switches from keyring 3.6 (whose client API is deprecated) to keyring-core 1.0 with per-platform store crates, introducing a Linux composite store that reads from secret-service first and lazily migrates legacy keyutils entries on hit so previously stored credentials remain readable on macOS, Windows and Linux. Drops the unmaintained portpicker crate in favour of a small std::net helper, replaces tauri-plugin-log with flexi_logger to take the byte-unit / rust_decimal / rand 0.8 chain out of the runtime dependency tree, and refreshes patch versions across the workspace.