### PR TITLE
fix(security): pin fuzz action to SHA and redact MCP session IDs in logs

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -36,7 +36,7 @@ jobs:
           toolchain: nightly
 
       - name: Install cargo-fuzz
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@50cee16bd6b97b2579572f83cfa1c0a721b1e336 # v2.65.2
         with:
           tool: cargo-fuzz@0.13.1
 

--- a/crates/kftray-mcp/src/server.rs
+++ b/crates/kftray-mcp/src/server.rs
@@ -266,7 +266,7 @@ async fn handle_mcp_delete(
     match session_id {
         Some(id) => {
             state.remove_session(id).await;
-            info!("Session terminated: {}", id);
+            info!("Session terminated: {}...", redact_session_id(id));
             Response::builder()
                 .status(StatusCode::OK)
                 .body(Full::new(Bytes::from("{\"status\":\"terminated\"}")))
@@ -277,6 +277,12 @@ async fn handle_mcp_delete(
             .body(Full::new(Bytes::from("Missing Mcp-Session-Id header")))
             .unwrap(),
     }
+}
+
+/// Truncate session ID for safe logging. Session IDs are bearer tokens; the
+/// 8-char prefix lets us correlate log lines without leaking the full token.
+fn redact_session_id(id: &str) -> String {
+    id.chars().take(8).collect()
 }
 
 /// Handle health check endpoint


### PR DESCRIPTION
## Summary

Resolves two open code scanning alerts on `main`:

- **[#78](https://github.com/hcavarsan/kftray/security/code-scanning/78)** — `OSSF Scorecard / Pinned-Dependencies` (medium): `.github/workflows/fuzz.yml` referenced `taiki-e/install-action@v2` instead of a SHA-pinned commit, leaving the build susceptible to a compromised tag. Pinned to `50cee16bd6b97b2579572f83cfa1c0a721b1e336` (v2.65.2), matching the existing pin in `ci.yml` so Renovate can update both files atomically.
- **[#75](https://github.com/hcavarsan/kftray/security/code-scanning/75)** — `rust/cleartext-logging` (high): `crates/kftray-mcp/src/server.rs` logged the full `mcp-session-id` header on session termination. Session IDs are bearer tokens, so anyone with log access could hijack an active session. Now logs only the first 8 characters via a small `redact_session_id` helper — enough for log correlation, no useful token material left.

## Out of scope

The remaining four open alerts on `main` were analyzed and intentionally not changed in this PR:

| Alert | Why not |
|-------|---------|
| #77 `rust/cleartext-logging` on `ssl.rs:46` | False positive — variable is `ssl_cert_validity_days: u16` (an integer like `365`), no secret involved. Recommend dismiss. |
| #76 `rust/cleartext-logging` on `server_resources.rs:71` | Logs OS username (PII at most, not a credential). Same rationale as previously dismissed alerts #63–#66. Recommend dismiss or demote to `debug!` separately. |
| #59 `Code-Review` (Scorecard) | Repository governance score, not a code change. Branch protection is already enabled. |
| #57 `CI-Tests` (Scorecard) | Scorecard heuristic limit; CI workflows already run on PRs. |

## Verification

- `cargo check -p kftray-mcp` — clean
- `cargo clippy -p kftray-mcp --all-targets -- -D warnings` — clean
- `cargo test -p kftray-mcp` — 49 passed, 0 failed
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/fuzz.yml'))"` — valid

## Changes

```
.github/workflows/fuzz.yml      | 2 +-
crates/kftray-mcp/src/server.rs | 8 +++++++-
2 files changed, 8 insertions(+), 2 deletions(-)
```