### PR TITLE
chore(deps): consolidate workspace dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,6 +169,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "asn1-rs"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -415,9 +424,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -425,9 +434,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -736,6 +745,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -935,6 +950,20 @@ dependencies = [
 
 [[package]]
 name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
+name = "compact_str"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
@@ -964,7 +993,7 @@ checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "unicode-width",
+ "unicode-width 0.2.0",
  "windows-sys 0.61.2",
 ]
 
@@ -3057,7 +3086,7 @@ checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
  "console",
  "portable-atomic",
- "unicode-width",
+ "unicode-width 0.2.0",
  "unit-prefix",
  "web-time",
 ]
@@ -3578,6 +3607,7 @@ dependencies = [
  "kftray-helper",
  "kftray-http-logs",
  "kube",
+ "kube-portforward",
  "kube-runtime",
  "lazy_static",
  "libc",
@@ -3622,7 +3652,6 @@ version = "0.27.30"
 dependencies = [
  "async-trait",
  "bytes",
- "env_logger",
  "futures",
  "http",
  "http-body-util",
@@ -3635,6 +3664,9 @@ dependencies = [
  "socket2",
  "tokio",
  "tokio-tungstenite 0.29.0",
+ "tokio-util",
+ "tracing",
+ "tracing-subscriber",
  "tungstenite 0.29.0",
  "url",
  "uuid",
@@ -3683,6 +3715,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
+ "mimalloc",
  "mockall",
  "netstat2",
  "open",
@@ -3728,7 +3761,8 @@ dependencies = [
  "kftray-portforward",
  "libc",
  "log",
- "ratatui",
+ "mimalloc",
+ "ratatui 0.30.0",
  "ratatui-explorer",
  "reqwest 0.13.3",
  "self_update",
@@ -3822,6 +3856,31 @@ dependencies = [
  "serde-value",
  "serde_json",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "kube-portforward"
+version = "0.1.0"
+dependencies = [
+ "arc-swap",
+ "bytes",
+ "dashmap",
+ "futures",
+ "http",
+ "hyper",
+ "hyper-util",
+ "k8s-openapi",
+ "kube",
+ "kube-runtime",
+ "parking_lot",
+ "quanta",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-tungstenite 0.29.0",
+ "tokio-util",
+ "tracing",
+ "tracing-subscriber",
+ "tungstenite 0.29.0",
 ]
 
 [[package]]
@@ -3940,6 +3999,15 @@ checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "libmimalloc-sys"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d1eacfa31c33ec25e873c136ba5669f00f9866d0688bea7be4d3f7e43067df6"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -4067,6 +4135,15 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "lru"
 version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
@@ -4141,6 +4218,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3627c4272df786b9260cabaa46aec1d59c93ede723d4c3ef646c503816b0640"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -5225,18 +5311,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5495,6 +5581,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5676,6 +5777,26 @@ checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags 2.11.1",
+ "cassowary",
+ "compact_str 0.8.1",
+ "indoc",
+ "instability",
+ "itertools 0.13.0",
+ "lru 0.12.5",
+ "paste",
+ "strum 0.26.3",
+ "unicode-segmentation",
+ "unicode-truncate 1.1.0",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "ratatui"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc"
@@ -5695,17 +5816,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
 dependencies = [
  "bitflags 2.11.1",
- "compact_str",
+ "compact_str 0.9.0",
  "hashbrown 0.16.1",
  "indoc",
  "itertools 0.14.0",
  "kasuari",
- "lru",
- "strum",
+ "lru 0.16.4",
+ "strum 0.27.2",
  "thiserror 2.0.18",
  "unicode-segmentation",
- "unicode-truncate",
- "unicode-width",
+ "unicode-truncate 2.0.1",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -5727,7 +5848,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1034d08c806b090cf2eb450f60717e38d28b3a0a9fae01eee282db488d2e513b"
 dependencies = [
  "educe",
- "ratatui",
+ "ratatui 0.30.0",
 ]
 
 [[package]]
@@ -5763,10 +5884,19 @@ dependencies = [
  "itertools 0.14.0",
  "line-clipping",
  "ratatui-core",
- "strum",
+ "strum 0.27.2",
  "time",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -6880,11 +7010,33 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.27.2",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7697,11 +7849,11 @@ dependencies = [
 
 [[package]]
 name = "throbber-widgets-tui"
-version = "0.11.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1e6941f74491a80911cb8821cb1f55f7e13bca867b28a2b14e5a1daaf691eb3"
+checksum = "45e58887883fb0a259717b16d68d251983e40850b4b2f45c2da410f46d4333dc"
 dependencies = [
- "ratatui",
+ "ratatui 0.29.0",
 ]
 
 [[package]]
@@ -7931,7 +8083,7 @@ dependencies = [
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -7994,7 +8146,7 @@ dependencies = [
  "indexmap 2.14.0",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -8003,7 +8155,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -8188,7 +8340,7 @@ dependencies = [
  "lazy_static",
  "log",
  "parking_lot",
- "ratatui",
+ "ratatui 0.30.0",
  "unicode-segmentation",
 ]
 
@@ -8322,20 +8474,37 @@ checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools 0.13.0",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-truncate"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
  "itertools 0.14.0",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
 name = "unicode-width"
-version = "0.2.2"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"
@@ -9532,9 +9701,9 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
@@ -9832,7 +10001,7 @@ dependencies = [
  "uds_windows",
  "uuid",
  "windows-sys 0.61.2",
- "winnow 1.0.2",
+ "winnow 1.0.3",
  "zbus_macros",
  "zbus_names",
  "zvariant",
@@ -9860,7 +10029,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
 dependencies = [
  "serde",
- "winnow 1.0.2",
+ "winnow 1.0.3",
  "zvariant",
 ]
 
@@ -10011,7 +10180,7 @@ dependencies = [
  "endi",
  "enumflags2",
  "serde",
- "winnow 1.0.2",
+ "winnow 1.0.3",
  "zvariant_derive",
  "zvariant_utils",
 ]
@@ -10039,5 +10208,5 @@ dependencies = [
  "quote",
  "serde",
  "syn 2.0.117",
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = ["crates/*"]
 [workspace.dependencies]
 anyhow = "1.0.102"
 apple-native-keyring-store = { version = "1.0", features = ["keychain"] }
+arc-swap = "1.9"
 async-trait = "0.1.89"
 base64 = "0.22"
 bb8 = "0.9.1"
@@ -15,6 +16,7 @@ built = "0.8"
 bytes = "1.11"
 chrono = { version = "0.4.44", features = ["serde"] }
 clap = { version = "4.6.1", features = ["derive"] }
+core-foundation = "0.10.1"
 crossterm = { version = "0.29", optional = false }
 dashmap = "6.1"
 dbus-secret-service-keyring-store = { version = "1.0", features = [
@@ -22,11 +24,13 @@ dbus-secret-service-keyring-store = { version = "1.0", features = [
 ] }
 dirs = "6.0"
 env_logger = "0.11"
+evdev = "0.13.2"
 fix-path-env = { git = "https://github.com/tauri-apps/fix-path-env-rs" }
 flate2 = "1.1"
 flexi_logger = "0.31"
 futures = "0.3"
 git2 = { version = "0.20", features = ["ssh"] }
+global-hotkey = "0.8.0"
 http = "1.4"
 http-body-util = "0.1"
 httparse = "1.10"
@@ -40,11 +44,14 @@ hyper-util = { version = "0.1.20", features = [
   "server",
   "tokio",
 ] }
+inotify = "0.11.1"
 insta = "1.47"
+jiff = { version = "0.2", features = ["serde"] }
 k8s-openapi = { version = "0.27.1", default-features = false, features = [
   "latest",
 ] }
 keyring-core = "1.0"
+ksni = "0.3"
 kftray-commons = { version = "0.27.30", path = "crates/kftray-commons" }
 kftray-helper = { version = "0.27.30", path = "crates/kftray-helper" }
 kftray-http-logs = { version = "0.27.30", path = "crates/kftray-http-logs" }
@@ -52,6 +59,7 @@ kftray-mcp = { version = "0.27.30", path = "crates/kftray-mcp" }
 kftray-network-monitor = { version = "0.27.30", path = "crates/kftray-network-monitor" }
 kftray-portforward = { version = "0.27.30", path = "crates/kftray-portforward" }
 kftray-shortcuts = { version = "0.27.30", path = "crates/kftray-shortcuts" }
+kube-portforward = { version = "0.1", path = "crates/kube-portforward" }
 kube = { version = "3.1.0", features = [
   "client",
   "config",
@@ -67,17 +75,22 @@ kube-runtime = { version = "3.1.0", features = ["unstable-runtime"] }
 lazy_static = "1.5"
 libc = "0.2.186"
 linux-keyutils-keyring-store = "1.0"
+mio = { version = "1.2.0", features = ["os-ext"] }
 log = "0.4"
+mimalloc = { version = "0.1", default-features = false }
 mockall = "0.14"
 netstat2 = "0.11.2"
 once_cell = "1.21"
 open = "5.3"
 openssl = { version = "0.10", features = ["vendored"] }
 openssl-sys = { version = "0.9", features = ["vendored"] }
+parking_lot = "0.12"
 pem = "3.0"
+png = "0.18"
 rand = "0.10"
 ratatui = { version = "0.30.0", features = ["unstable-widget-ref"] }
 ratatui-explorer = "0.3.0"
+quanta = "0.12"
 rcgen = "0.14"
 reqwest = "0.13.3"
 rustls = { version = "0.23", default-features = false, features = [
@@ -86,7 +99,10 @@ rustls = { version = "0.23", default-features = false, features = [
   "tls12",
 ] }
 rustls-native-certs = "0.8.3"
+schannel = "0.1.29"
 secrecy = "0.10"
+security-framework = "3.7.0"
+self_update = { version = "0.44.0", features = ["archive-tar", "compression-flate2"] }
 semver = "1.0.28"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
@@ -120,7 +136,7 @@ tauri-plugin-shell = "2.3.5"
 tauri-plugin-updater = "2.10.1"
 tempfile = "3.27.0"
 thiserror = "2.0.18"
-throbber-widgets-tui = "0.11.0"
+throbber-widgets-tui = "0.9.0"
 time = "0.3"
 tokio = { version = "1.52.3", features = [
   "fs",

--- a/crates/kftray-shortcuts/Cargo.toml
+++ b/crates/kftray-shortcuts/Cargo.toml
@@ -12,7 +12,7 @@ license = "GPL-3.0"
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
-global-hotkey = "0.8.0"
+global-hotkey = { workspace = true }
 log = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -21,8 +21,8 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-evdev = "0.13.2"
-mio = { version = "1.2.0", features = ["os-ext"] }
+evdev = { workspace = true }
+mio = { workspace = true }
 
 [features]
 default = []


### PR DESCRIPTION
## Stack Context

This stack restructures the `websocket-pf` branch into 11 atomic PRs.
The goal is to extract a standalone `kube-portforward` crate (OSS-ready
WebSocket port-forwarder for Kubernetes) and rebuild kftray's port-forward
path on top of it, with a new HTTP proxy in kftray-server.

Stack order (bottom to top):
1. ws-pf/dev-tooling — dev tooling and gitignore
2. ws-pf/workspace-deps — workspace dependency consolidation
3. ws-pf/kube-portforward-crate — new kube-portforward crate
4. ws-pf/portforward-deps — wire kftray-portforward to new crate
5. ws-pf/ssl-platform-cleanup — remove dead SSL platform code
6. ws-pf/server-http-proxy — HTTP proxy with relay and sniffer
7. ws-pf/kube-registry-refactor — registry + kube listener rebuilt
8. ws-pf/expose-updates — expose flows through new registry
9. ws-pf/network-monitor-fix — PortForwardError type fix
10. ws-pf/tauri-integration — tauri command wiring
11. ws-pf/kftui-integration — kftui integration (top)

## Why?

Centralizes all dependency version pins into `[workspace.dependencies]` in the root `Cargo.toml`. Eliminates version drift between crates and makes future upgrades a single-point change. `kftray-shortcuts/Cargo.toml` updated for the same reason.

## What?

- `Cargo.toml` (workspace.dependencies section)
- `Cargo.lock`
- `crates/kftray-shortcuts/Cargo.toml`
