### PR TITLE
feat(kube-portforward): introduce standalone websocket port-forward crate

### DIFF
--- a/crates/kube-portforward/Cargo.toml
+++ b/crates/kube-portforward/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "kube-portforward"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.85"
+description = "Production-ready Kubernetes port-forward over WebSocket with channel multiplexing"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/hcavarsan/kftray"
+keywords = ["kubernetes", "portforward", "websocket", "async", "tokio"]
+categories = ["network-programming", "asynchronous"]
+
+[dependencies]
+arc-swap = { workspace = true }
+bytes = { workspace = true }
+futures = { workspace = true }
+http = { workspace = true }
+hyper = { workspace = true }
+hyper-util = { workspace = true }
+k8s-openapi = { workspace = true }
+kube = { workspace = true }
+kube-runtime = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tokio-tungstenite = { workspace = true }
+tokio-util = { workspace = true }
+tracing = { workspace = true }
+tungstenite = { workspace = true }
+dashmap = { workspace = true }
+parking_lot = { workspace = true }
+quanta = { workspace = true }
+
+[features]
+default = []
+# Built-in apiserver version cache (TTL 1h).
+# Off by default; consumers can implement their own caching strategy.
+version-cache = []
+
+[dev-dependencies]
+k8s-openapi = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+tracing-subscriber = { workspace = true }

--- a/crates/kube-portforward/LICENSE-APACHE
+++ b/crates/kube-portforward/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for describing the origin of the Work and
+      reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Support. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or support.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright Henrique Cavarsan and kftray contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/crates/kube-portforward/LICENSE-MIT
+++ b/crates/kube-portforward/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Henrique Cavarsan and kftray contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/kube-portforward/README.md
+++ b/crates/kube-portforward/README.md
@@ -1,0 +1,62 @@
+# kube-portforward
+
+Production-ready Kubernetes port-forward over WebSocket with channel multiplexing.
+
+Speaks `v5.channel.k8s.io` (preferred) and `v4.channel.k8s.io` (fallback) per
+[KEP-4006](https://github.com/kubernetes/enhancements/issues/4006). Multiplexes
+N concurrent local TCP connections over ONE WebSocket upgrade by encoding the
+target pod port N times in the URL.
+
+## Why not `kube::Api::portforward`?
+
+| Feature                                | `kube::Api::portforward` | `kube-portforward` |
+|----------------------------------------|--------------------------|--------------------|
+| WebSocket transport                    | Yes                      | Yes                |
+| Channel multiplexing over one WS       | No (one upgrade per pair)| Yes (N pairs)      |
+| `v5.channel.k8s.io` half-close support | Limited                  | Yes (ID reuse)     |
+| Keepalive Ping + watchdog              | No                       | Yes (15s/30s)      |
+| Graceful shutdown drain                | No                       | Yes (configurable) |
+| Pre-1.30 detection with KEP-4006 hint  | Opaque `kube::Error`     | `ServerVersionTooOld` |
+| Structured `thiserror` errors          | No                       | Yes                |
+| Builder-pattern config                 | No                       | Yes                |
+| Pluggable recovery callback            | No                       | Yes                |
+
+## Option B Multiplexing
+
+For each session, the URL encodes the target port N times:
+
+```
+?ports=9200&ports=9200&...&ports=9200
+```
+
+The apiserver and kubelet allocate 2N channel IDs at handshake (a data/error
+pair per URL occurrence). Channel pair `(2i, 2i+1)` corresponds to URL
+position `i`. The allocator hands pairs out in URL order — first call
+returns `(0, 1)`, second `(2, 3)`, and so on.
+
+On `v5`, the half-close signal `[0xFF, channel]` releases an ID pair back
+to the free-list, letting one session sustain a high turnover of short-lived
+local connections. On `v4`, released pairs stay reserved for the session
+lifetime.
+
+## Quick Start
+
+```rust,no_run
+use kube_portforward::Client;
+use tokio::io::AsyncWriteExt;
+
+# async fn run(kube: kube::Client, url: http::Uri) -> Result<(), Box<dyn std::error::Error>> {
+let client = Client::new(kube, url);
+let session = client.session("default", "nginx", 80).open().await?;
+let mut stream = session.connect().await?;
+stream.write_all(b"GET / HTTP/1.0\r\n\r\n").await?;
+session.close().await?;
+# Ok(()) }
+```
+
+See `examples/` for end-to-end usage including multiplexing, custom keepalive
+timings, and graceful shutdown.
+
+## License
+
+Dual-licensed under MIT or Apache-2.0, at your option.

--- a/crates/kube-portforward/examples/graceful_shutdown.rs
+++ b/crates/kube-portforward/examples/graceful_shutdown.rs
@@ -1,0 +1,35 @@
+use std::time::Duration;
+
+use kube_portforward::Client;
+use tokio_util::sync::CancellationToken;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt::init();
+
+    let kube_client = kube::Client::try_default().await?;
+    let cluster_url: http::Uri = "https://kubernetes.default.svc".parse()?;
+    let cancel = CancellationToken::new();
+
+    let client = Client::new(kube_client, cluster_url);
+    let session = client
+        .session("default", "nginx", 80)
+        .shutdown_grace(Duration::from_secs(3))
+        .cancellation_token(cancel.clone())
+        .open()
+        .await?;
+
+    let _stream = session.connect().await?;
+
+    tokio::spawn({
+        let cancel = cancel.clone();
+        async move {
+            tokio::time::sleep(Duration::from_secs(5)).await;
+            cancel.cancel();
+        }
+    });
+
+    cancel.cancelled().await;
+    session.close().await?;
+    Ok(())
+}

--- a/crates/kube-portforward/examples/multiplex.rs
+++ b/crates/kube-portforward/examples/multiplex.rs
@@ -1,0 +1,52 @@
+use std::sync::Arc;
+
+use kube_portforward::Client;
+use tokio::io::{
+    AsyncReadExt,
+    AsyncWriteExt,
+};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt::init();
+
+    let kube_client = kube::Client::try_default().await?;
+    let cluster_url: http::Uri = "https://kubernetes.default.svc".parse()?;
+
+    let client = Client::new(kube_client, cluster_url);
+    let session = Arc::new(
+        client
+            .session("default", "nginx", 80)
+            .capacity(10)
+            .open()
+            .await?,
+    );
+
+    let mut handles = Vec::new();
+    for i in 0..10 {
+        let s = Arc::clone(&session);
+        handles.push(tokio::spawn(async move {
+            let mut stream = s.connect().await?;
+            stream
+                .write_all(format!("GET /?q={i} HTTP/1.0\r\n\r\n").as_bytes())
+                .await?;
+            let mut buf = vec![0u8; 4096];
+            let n = stream.read(&mut buf).await?;
+            Ok::<_, Box<dyn std::error::Error + Send + Sync>>(n)
+        }));
+    }
+
+    for h in handles {
+        match h.await? {
+            Ok(n) => println!("stream got {n} bytes"),
+            Err(e) => eprintln!("stream failed: {e}"),
+        }
+    }
+
+    Arc::try_unwrap(session)
+        .ok()
+        .expect("sessions still shared")
+        .close()
+        .await?;
+    Ok(())
+}

--- a/crates/kube-portforward/examples/single_port.rs
+++ b/crates/kube-portforward/examples/single_port.rs
@@ -1,0 +1,26 @@
+use kube_portforward::Client;
+use tokio::io::{
+    AsyncReadExt,
+    AsyncWriteExt,
+};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt::init();
+
+    let kube_client = kube::Client::try_default().await?;
+    let cluster_url: http::Uri = "https://kubernetes.default.svc".parse()?;
+
+    let client = Client::new(kube_client, cluster_url);
+    let session = client.session("default", "nginx", 80).open().await?;
+    println!("negotiated subprotocol: {:?}", session.protocol());
+
+    let mut stream = session.connect().await?;
+    stream.write_all(b"GET / HTTP/1.0\r\n\r\n").await?;
+    let mut buf = vec![0u8; 4096];
+    let n = stream.read(&mut buf).await?;
+    println!("got {} bytes back", n);
+
+    session.close().await?;
+    Ok(())
+}

--- a/crates/kube-portforward/examples/with_keepalive.rs
+++ b/crates/kube-portforward/examples/with_keepalive.rs
@@ -1,0 +1,29 @@
+use std::time::Duration;
+
+use kube_portforward::{
+    Client,
+    RecoverySignal,
+};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt::init();
+
+    let kube_client = kube::Client::try_default().await?;
+    let cluster_url: http::Uri = "https://kubernetes.default.svc".parse()?;
+
+    let client = Client::new(kube_client, cluster_url);
+    let session = client
+        .session("default", "nginx", 80)
+        .keepalive(Duration::from_secs(5), Duration::from_secs(15))
+        .on_recovery(|signal: RecoverySignal| {
+            eprintln!("recovery: {signal:?}");
+        })
+        .open()
+        .await?;
+
+    let _stream = session.connect().await?;
+    tokio::time::sleep(Duration::from_secs(30)).await;
+    session.close().await?;
+    Ok(())
+}

--- a/crates/kube-portforward/src/allocator.rs
+++ b/crates/kube-portforward/src/allocator.rs
@@ -1,0 +1,180 @@
+use std::collections::{
+    HashSet,
+    VecDeque,
+};
+
+/// FIFO channel-pair allocator aligned with the URL-position semantics of
+/// the Kubernetes port-forward subprotocols. The first allocation returns
+/// `(0, 1)`, the second `(2, 3)`, and so on.
+///
+/// Channel pairs are **one-shot**: once a pair has been allocated, the
+/// apiserver binds it to a single backend pod connection at WebSocket
+/// upgrade time. After either side sends the v5 `[0xFF, channel]` close
+/// signal, the pair is dead for the rest of the session — the server
+/// will not accept reuse. Therefore `release_pair` only decrements the
+/// live-count bookkeeping; it does **not** push the IDs back onto the
+/// free-list.
+pub(crate) struct ChannelAllocator {
+    free: VecDeque<u8>,
+    in_use: HashSet<u8>,
+    capacity_pairs: usize,
+    poisoned: bool,
+    total_allocated: usize,
+}
+
+impl ChannelAllocator {
+    pub(crate) fn new(capacity_pairs: usize) -> Self {
+        let free: VecDeque<u8> = (0u8..).step_by(2).take(capacity_pairs).collect();
+        Self {
+            free,
+            in_use: HashSet::new(),
+            capacity_pairs,
+            poisoned: false,
+            total_allocated: 0,
+        }
+    }
+
+    pub(crate) fn allocate_pair(&mut self) -> Option<(u8, u8)> {
+        if self.poisoned {
+            return None;
+        }
+        let data = self.free.pop_front()?;
+        let error = data + 1;
+        self.in_use.insert(data);
+        self.in_use.insert(error);
+        self.total_allocated += 1;
+        Some((data, error))
+    }
+
+    /// Returns true once every preallocated pair has been handed out and
+    /// every outstanding allocation has been released. A drained allocator
+    /// can never produce another pair (v5 channel IDs are one-shot per the
+    /// K8s wire protocol), so callers should retire the owning session.
+    pub(crate) fn is_drained(&self) -> bool {
+        self.total_allocated >= self.capacity_pairs && self.in_use.is_empty()
+    }
+
+    /// Decrement live-count for a previously allocated pair. The IDs are
+    /// **not** returned to the free-list because v5 channel pairs are
+    /// one-shot per K8s portforward semantics (see type-level docs).
+    pub(crate) fn release_pair(&mut self, data: u8) {
+        self.in_use.remove(&data);
+        self.in_use.remove(&(data + 1));
+    }
+
+    pub(crate) fn live_count(&self) -> usize {
+        self.in_use.len() / 2
+    }
+
+    pub(crate) fn capacity_pairs(&self) -> usize {
+        self.capacity_pairs
+    }
+
+    pub(crate) fn is_full(&self) -> bool {
+        self.free.is_empty()
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn set_poisoned(&mut self) {
+        self.poisoned = true;
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn is_poisoned(&self) -> bool {
+        self.poisoned
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn allocates_in_url_order() {
+        let mut a = ChannelAllocator::new(4);
+        assert_eq!(a.allocate_pair(), Some((0, 1)));
+        assert_eq!(a.allocate_pair(), Some((2, 3)));
+        assert_eq!(a.allocate_pair(), Some((4, 5)));
+        assert_eq!(a.allocate_pair(), Some((6, 7)));
+        assert_eq!(a.allocate_pair(), None);
+    }
+
+    #[test]
+    fn release_decrements_live_count() {
+        let mut a = ChannelAllocator::new(4);
+        let first = a.allocate_pair().unwrap();
+        let second = a.allocate_pair().unwrap();
+        assert_eq!(a.live_count(), 2);
+        a.release_pair(first.0);
+        assert_eq!(a.live_count(), 1);
+        assert_eq!(a.allocate_pair(), Some((4, 5)));
+        assert_eq!(a.live_count(), 2);
+        assert_eq!(second, (2, 3));
+    }
+
+    #[test]
+    fn capacity_exhaustion_returns_none() {
+        let mut a = ChannelAllocator::new(1);
+        assert!(a.allocate_pair().is_some());
+        assert!(a.allocate_pair().is_none());
+    }
+
+    #[test]
+    fn released_pair_is_not_reused() {
+        let mut a = ChannelAllocator::new(2);
+        let first = a.allocate_pair().unwrap();
+        a.release_pair(first.0);
+        let next = a.allocate_pair().unwrap();
+        assert_ne!(next.0, first.0);
+        assert_eq!(next, (2, 3));
+        assert!(a.allocate_pair().is_none());
+    }
+
+    #[test]
+    fn poisoning_short_circuits() {
+        let mut a = ChannelAllocator::new(4);
+        a.set_poisoned();
+        assert!(a.is_poisoned());
+        assert!(a.allocate_pair().is_none());
+    }
+
+    #[test]
+    fn is_drained_after_full_cycle() {
+        let mut a = ChannelAllocator::new(3);
+        assert!(!a.is_drained());
+        let p0 = a.allocate_pair().unwrap();
+        let p1 = a.allocate_pair().unwrap();
+        assert!(!a.is_drained());
+        let p2 = a.allocate_pair().unwrap();
+        assert!(!a.is_drained());
+        a.release_pair(p0.0);
+        a.release_pair(p1.0);
+        assert!(!a.is_drained());
+        a.release_pair(p2.0);
+        assert!(a.is_drained());
+    }
+
+    #[test]
+    fn drained_when_all_used_and_released() {
+        let mut a = ChannelAllocator::new(2);
+        let p0 = a.allocate_pair().unwrap();
+        let p1 = a.allocate_pair().unwrap();
+        assert!(a.allocate_pair().is_none());
+        assert!(!a.is_drained());
+        a.release_pair(p0.0);
+        assert!(!a.is_drained());
+        a.release_pair(p1.0);
+        assert!(a.is_drained());
+    }
+
+    #[test]
+    fn live_count_tracks_pairs() {
+        let mut a = ChannelAllocator::new(4);
+        assert_eq!(a.live_count(), 0);
+        a.allocate_pair();
+        a.allocate_pair();
+        assert_eq!(a.live_count(), 2);
+        a.release_pair(0);
+        assert_eq!(a.live_count(), 1);
+    }
+}

--- a/crates/kube-portforward/src/client.rs
+++ b/crates/kube-portforward/src/client.rs
@@ -1,0 +1,184 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio_util::sync::CancellationToken;
+
+use crate::connect::{
+    KeepaliveConfig,
+    open_session,
+};
+use crate::error::Error;
+use crate::keepalive::{
+    RecoveryCallback,
+    RecoverySignal,
+};
+use crate::session::Session;
+use crate::subprotocol::Subprotocol;
+
+const DEFAULT_CAPACITY: usize = 64;
+const MAX_CAPACITY: usize = 127;
+const DEFAULT_PING: Duration = Duration::from_secs(15);
+const DEFAULT_WATCHDOG: Duration = Duration::from_secs(30);
+const DEFAULT_DRAIN: Duration = Duration::from_secs(2);
+
+/// Top-level entry point bundling a `kube::Client` with its cluster URL.
+#[derive(Clone)]
+pub struct Client {
+    kube: kube::Client,
+    cluster_url: http::Uri,
+}
+
+impl Client {
+    pub fn new(kube_client: kube::Client, cluster_url: http::Uri) -> Self {
+        Self {
+            kube: kube_client,
+            cluster_url,
+        }
+    }
+
+    pub fn builder() -> ClientBuilder {
+        ClientBuilder::default()
+    }
+
+    pub fn session<'c>(
+        &'c self, namespace: impl Into<String>, pod: impl Into<String>, port: u16,
+    ) -> SessionBuilder<'c> {
+        SessionBuilder {
+            client: self,
+            namespace: namespace.into(),
+            pod: pod.into(),
+            port,
+            capacity: DEFAULT_CAPACITY,
+            subprotocols: vec![Subprotocol::V5, Subprotocol::V4],
+            ping_interval: DEFAULT_PING,
+            watchdog_timeout: DEFAULT_WATCHDOG,
+            drain_timeout: DEFAULT_DRAIN,
+            cancel: None,
+            recovery_callback: None,
+        }
+    }
+
+    pub fn kube_client(&self) -> &kube::Client {
+        &self.kube
+    }
+
+    pub fn cluster_url(&self) -> &http::Uri {
+        &self.cluster_url
+    }
+}
+
+#[derive(Default)]
+pub struct ClientBuilder {
+    kube: Option<kube::Client>,
+    cluster_url: Option<http::Uri>,
+}
+
+impl ClientBuilder {
+    pub fn kube_client(mut self, c: kube::Client) -> Self {
+        self.kube = Some(c);
+        self
+    }
+
+    pub fn cluster_url(mut self, u: http::Uri) -> Self {
+        self.cluster_url = Some(u);
+        self
+    }
+
+    pub fn build(self) -> Result<Client, Error> {
+        let kube = self
+            .kube
+            .ok_or_else(|| Error::Configuration("kube_client is required".into()))?;
+        let cluster_url = self
+            .cluster_url
+            .ok_or_else(|| Error::Configuration("cluster_url is required".into()))?;
+        Ok(Client::new(kube, cluster_url))
+    }
+}
+
+/// Builder for opening a [`Session`].
+pub struct SessionBuilder<'c> {
+    client: &'c Client,
+    namespace: String,
+    pod: String,
+    port: u16,
+    capacity: usize,
+    subprotocols: Vec<Subprotocol>,
+    ping_interval: Duration,
+    watchdog_timeout: Duration,
+    drain_timeout: Duration,
+    cancel: Option<CancellationToken>,
+    recovery_callback: Option<RecoveryCallback>,
+}
+
+impl<'c> SessionBuilder<'c> {
+    /// Number of pre-allocated channel pairs (default 64, max 127).
+    /// Cap is 127 because each pair uses (data, error) channel IDs and
+    /// 127 * 2 = 254 fits in the single-byte channel space (0xFF).
+    pub fn capacity(mut self, n: usize) -> Self {
+        self.capacity = n;
+        self
+    }
+
+    pub fn subprotocols(mut self, prefs: &[Subprotocol]) -> Self {
+        self.subprotocols = prefs.to_vec();
+        self
+    }
+
+    pub fn keepalive(mut self, ping: Duration, watchdog: Duration) -> Self {
+        self.ping_interval = ping;
+        self.watchdog_timeout = watchdog;
+        self
+    }
+
+    pub fn shutdown_grace(mut self, drain: Duration) -> Self {
+        self.drain_timeout = drain;
+        self
+    }
+
+    pub fn cancellation_token(mut self, t: CancellationToken) -> Self {
+        self.cancel = Some(t);
+        self
+    }
+
+    pub fn on_recovery<F>(mut self, cb: F) -> Self
+    where
+        F: Fn(RecoverySignal) + Send + Sync + 'static,
+    {
+        self.recovery_callback = Some(Arc::new(cb));
+        self
+    }
+
+    pub async fn open(self) -> Result<Session, Error> {
+        if self.capacity == 0 {
+            return Err(Error::Configuration("capacity must be > 0".into()));
+        }
+        if self.capacity > MAX_CAPACITY {
+            return Err(Error::Configuration(format!(
+                "capacity {} exceeds maximum of {MAX_CAPACITY}",
+                self.capacity
+            )));
+        }
+        let cancel = self.cancel.unwrap_or_default();
+        let recovery_callback: RecoveryCallback = self
+            .recovery_callback
+            .unwrap_or_else(|| Arc::new(|_signal| {}));
+
+        open_session(
+            self.client.kube_client(),
+            self.client.cluster_url(),
+            &self.namespace,
+            &self.pod,
+            self.port,
+            self.capacity,
+            &self.subprotocols,
+            cancel,
+            KeepaliveConfig {
+                ping_interval: self.ping_interval,
+                watchdog_timeout: self.watchdog_timeout,
+            },
+            self.drain_timeout,
+            recovery_callback,
+        )
+        .await
+    }
+}

--- a/crates/kube-portforward/src/connect.rs
+++ b/crates/kube-portforward/src/connect.rs
@@ -1,0 +1,216 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::StreamExt;
+use http::{
+    Method,
+    Request,
+    Uri,
+    header,
+};
+use parking_lot::Mutex;
+use tokio::sync::mpsc;
+use tokio::task::JoinSet;
+use tokio_tungstenite::WebSocketStream;
+use tokio_tungstenite::tungstenite::protocol::{
+    Role,
+    WebSocketConfig,
+};
+use tokio_util::sync::CancellationToken;
+use tungstenite::Message;
+
+use crate::allocator::ChannelAllocator;
+use crate::error::Error;
+use crate::keepalive::{
+    RecoveryCallback,
+    RecoverySignal,
+    spawn_keepalive,
+};
+use crate::reader::spawn_reader;
+use crate::routing::Router;
+use crate::session::Session;
+use crate::subprotocol::Subprotocol;
+use crate::version;
+use crate::writer::writer_task;
+
+fn name_is_valid(s: &str) -> bool {
+    !s.is_empty()
+        && s.is_ascii()
+        && s.bytes()
+            .all(|b| !matches!(b, b'/' | b'?' | b'#') && !b.is_ascii_control())
+}
+
+pub(crate) fn build_portforward_request(
+    cluster_url: &Uri, namespace: &str, pod: &str, port: u16, capacity_pairs: usize,
+) -> Result<Request<Vec<u8>>, Error> {
+    if !name_is_valid(namespace) || !name_is_valid(pod) {
+        return Err(Error::Configuration(
+            "invalid namespace or pod name: contains forbidden character or non-ASCII".into(),
+        ));
+    }
+    if capacity_pairs == 0 {
+        return Err(Error::Configuration("capacity_pairs must be > 0".into()));
+    }
+    let path = format!("/api/v1/namespaces/{namespace}/pods/{pod}/portforward");
+    let query = (0..capacity_pairs)
+        .map(|_| format!("ports={port}"))
+        .collect::<Vec<_>>()
+        .join("&");
+    let scheme = cluster_url
+        .scheme()
+        .ok_or_else(|| Error::Configuration("cluster_url is missing scheme".into()))?;
+    let authority = cluster_url
+        .authority()
+        .ok_or_else(|| Error::Configuration("cluster_url is missing authority".into()))?;
+    let uri: Uri = format!("{scheme}://{authority}{path}?{query}")
+        .parse()
+        .map_err(|e: http::uri::InvalidUri| {
+            Error::Configuration(format!("invalid port-forward URI: {e}"))
+        })?;
+    Request::builder()
+        .method(Method::GET)
+        .uri(uri)
+        .header(
+            header::SEC_WEBSOCKET_PROTOCOL,
+            Subprotocol::offered_header_value(),
+        )
+        .body(Vec::new())
+        .map_err(|e: http::Error| {
+            Error::Configuration(format!("failed to build port-forward request: {e}"))
+        })
+}
+
+pub(crate) struct KeepaliveConfig {
+    pub ping_interval: Duration,
+    pub watchdog_timeout: Duration,
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn open_session(
+    kube_client: &kube::Client, cluster_url: &Uri, namespace: &str, pod: &str, port: u16,
+    capacity_pairs: usize, _subprotocols: &[Subprotocol], cancel: CancellationToken,
+    keepalive_config: KeepaliveConfig, drain_timeout: Duration,
+    recovery_callback: RecoveryCallback,
+) -> Result<Session, Error> {
+    let request = build_portforward_request(cluster_url, namespace, pod, port, capacity_pairs)?;
+
+    let request_uri = request.uri().clone();
+    let offered_protocols = request
+        .headers()
+        .get(header::SEC_WEBSOCKET_PROTOCOL)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("<none>")
+        .to_string();
+    tracing::debug!(
+        uri = %request_uri,
+        sec_websocket_protocol = %offered_protocols,
+        capacity_pairs,
+        "open_session: sending WebSocket upgrade request"
+    );
+
+    let t_upgrade = std::time::Instant::now();
+    let connection = match kube_client.connect(request).await {
+        Ok(c) => c,
+        Err(e) => {
+            let msg = e.to_string();
+            tracing::debug!(error = %msg, "open_session: WebSocket upgrade failed");
+            recovery_callback(RecoverySignal::UpgradeFailed {
+                status: None,
+                message: msg,
+            });
+            // Attempt version detection to give a better error for old clusters
+            return match version::detect(kube_client).await {
+                Ok(info) if !info.supports_ws_portforward() => Err(Error::ServerVersionTooOld {
+                    detected: info.git_version,
+                    required: "1.30",
+                }),
+                // Preserve original kube::Error via #[from] variant
+                _ => Err(Error::Kube(e)),
+            };
+        }
+    };
+
+    let negotiated = if connection.supports_stream_close() {
+        "v5.channel.k8s.io"
+    } else {
+        "v4.channel.k8s.io"
+    };
+    tracing::info!(
+        pod = %pod,
+        port,
+        elapsed_ms = t_upgrade.elapsed().as_millis() as u64,
+        negotiated_protocol = negotiated,
+        "open_session: kube_client.connect upgrade complete"
+    );
+
+    let protocol = if connection.supports_stream_close() {
+        Subprotocol::V5
+    } else {
+        Subprotocol::V4
+    };
+
+    let mut join_set: JoinSet<Result<(), Error>> = JoinSet::new();
+    let (writer_tx, writer_rx) = mpsc::channel::<Message>(256);
+
+    let keepalive = spawn_keepalive(
+        writer_tx.clone(),
+        cancel.clone(),
+        Arc::clone(&recovery_callback),
+        keepalive_config.ping_interval,
+        keepalive_config.watchdog_timeout,
+        &mut join_set,
+    );
+
+    let raw = connection.into_stream().into_inner();
+    // WebSocketConfig is #[non_exhaustive], so struct-update syntax is not
+    // available
+    let mut ws_config = WebSocketConfig::default();
+    ws_config.max_message_size = Some(64 * 1024 * 1024);
+    ws_config.max_frame_size = Some(16 * 1024 * 1024);
+    let ws = WebSocketStream::from_raw_socket(raw, Role::Client, Some(ws_config)).await;
+    let (sink, stream) = ws.split();
+    join_set.spawn(writer_task(sink, writer_rx, cancel.clone()));
+    let router = Router::new();
+
+    // Pre-register every channel the apiserver pre-allocated at handshake
+    // (2 per `?ports=` URL occurrence) with a discard sender. The server
+    // sends one initial port-frame per channel right after the upgrade
+    // completes; without pre-registration those frames arrive before any
+    // user-driven Session::connect() call and would be dropped, leaving
+    // routing in port_seen=false for IDs that already had their port-frame.
+    // The next real payload would then be misparsed as a port-frame and
+    // silently swallowed.
+    for pair_index in 0..capacity_pairs {
+        let data_id = (pair_index as u8) * 2;
+        let error_id = data_id + 1;
+        let (discard_tx_data, _) = mpsc::channel::<bytes::Bytes>(1);
+        let (discard_tx_error, _) = mpsc::channel::<bytes::Bytes>(1);
+        router.insert(data_id, discard_tx_data, false);
+        router.insert(error_id, discard_tx_error, false);
+    }
+
+    spawn_reader(
+        protocol,
+        stream,
+        router.clone(),
+        writer_tx.clone(),
+        cancel.clone(),
+        keepalive.clone(),
+        Arc::clone(&recovery_callback),
+        &mut join_set,
+    );
+
+    let allocator = Arc::new(Mutex::new(ChannelAllocator::new(capacity_pairs)));
+
+    Ok(Session::new(
+        allocator,
+        router,
+        writer_tx,
+        cancel,
+        keepalive,
+        protocol,
+        join_set,
+        drain_timeout,
+        recovery_callback,
+    ))
+}

--- a/crates/kube-portforward/src/error.rs
+++ b/crates/kube-portforward/src/error.rs
@@ -1,0 +1,46 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+#[non_exhaustive]
+pub enum Error {
+    #[error("WebSocket upgrade failed (HTTP {status:?}): {message}")]
+    UpgradeFailed {
+        status: Option<u16>,
+        message: String,
+    },
+
+    #[error(
+        "Kubernetes API server version {detected} does not support WebSocket port-forward; \
+         minimum required is {required} (KEP-4006). Upgrade the cluster or use SPDY portforward instead."
+    )]
+    ServerVersionTooOld {
+        detected: String,
+        required: &'static str,
+    },
+
+    #[error("WebSocket protocol violation in {context}: {detail}")]
+    ProtocolViolation {
+        context: &'static str,
+        detail: String,
+    },
+
+    #[error("Session capacity exhausted: {in_use}/{capacity} channel pairs in use")]
+    CapacityExhausted { in_use: usize, capacity: usize },
+
+    // TODO: Consider adding typed source variants (e.g. `ConfigurationSource { message, #[source]
+    // source }`) to preserve error provenance. Currently stringly-typed for simplicity in a
+    // pre-1.0 crate.
+    #[error("Configuration error: {0}")]
+    Configuration(String),
+
+    // TODO: Same as Configuration — consider carrying a `#[source]` field to preserve original
+    // error chain.
+    #[error("Network error: {0}")]
+    Network(String),
+
+    #[error(transparent)]
+    Kube(#[from] kube::Error),
+
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+}

--- a/crates/kube-portforward/src/forwarder.rs
+++ b/crates/kube-portforward/src/forwarder.rs
@@ -1,0 +1,710 @@
+//! Long-lived port-forward orchestrator.
+//!
+//! [`Forwarder`] sits above [`Session`] and owns:
+//!
+//! - a [`PodWatcher`] tracking the currently ready pod,
+//! - a bounded pool of [`Session`]s drained-on-pod-change,
+//! - prune and prefetch background tasks.
+//!
+//! Callers get a [`Stream`] from [`Forwarder::connect`] without thinking
+//! about pod identity, capacity, or recreation after pod rollover.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use quanta::Instant;
+use tokio::sync::{
+    Mutex as TokioMutex,
+    RwLock as TokioRwLock,
+    Semaphore,
+};
+use tokio::task::JoinSet;
+use tokio_util::sync::CancellationToken;
+use tracing::debug;
+
+use crate::client::Client;
+use crate::error::Error;
+use crate::keepalive::{
+    RecoveryCallback,
+    RecoverySignal,
+};
+use crate::pod_watch::{
+    PodChange,
+    PodSelector,
+    PodWatcher,
+};
+use crate::session::Session;
+use crate::stream::Stream;
+
+/// Drain all sessions from the pool under a write lock, then cancel each
+/// session's cancellation token outside the lock.
+async fn drain_and_cancel_all(sessions: &TokioRwLock<SessionPool>) {
+    let drained: Vec<PooledSession> = {
+        let mut pool = sessions.write().await;
+        pool.target_pod_uid = None;
+        pool.entries.drain(..).collect()
+    };
+    for pooled in drained {
+        pooled.session.cancellation_token().cancel();
+    }
+}
+
+const DEFAULT_MAX_SESSIONS: usize = 128;
+const DEFAULT_SESSION_CAPACITY: usize = 1;
+const DEFAULT_PING: Duration = Duration::from_secs(15);
+const DEFAULT_WATCHDOG: Duration = Duration::from_secs(30);
+const DEFAULT_DRAIN: Duration = Duration::from_secs(2);
+const DEFAULT_PRUNE_INTERVAL: Duration = Duration::from_secs(30);
+const DEFAULT_PRUNE_IDLE_AGE: Duration = Duration::from_secs(60);
+const DEFAULT_PREFETCH_THRESHOLD: f32 = 0.75;
+const READY_POD_WAIT: Duration = Duration::from_secs(5);
+const CONNECTION_SLOT_TIMEOUT: Duration = Duration::from_secs(10);
+const CONNECTION_SLOT_PERMITS: usize = 50;
+
+#[derive(Clone, Copy)]
+struct KeepaliveConfig {
+    ping: Duration,
+    watchdog: Duration,
+}
+
+#[derive(Clone, Copy)]
+struct ForwarderConfig {
+    max_sessions: usize,
+    session_capacity: usize,
+    keepalive: KeepaliveConfig,
+    shutdown_grace: Duration,
+    prune_interval: Duration,
+    prune_idle_age: Duration,
+    prefetch_threshold: f32,
+}
+
+impl Default for ForwarderConfig {
+    fn default() -> Self {
+        Self {
+            max_sessions: DEFAULT_MAX_SESSIONS,
+            session_capacity: DEFAULT_SESSION_CAPACITY,
+            keepalive: KeepaliveConfig {
+                ping: DEFAULT_PING,
+                watchdog: DEFAULT_WATCHDOG,
+            },
+            shutdown_grace: DEFAULT_DRAIN,
+            prune_interval: DEFAULT_PRUNE_INTERVAL,
+            prune_idle_age: DEFAULT_PRUNE_IDLE_AGE,
+            prefetch_threshold: DEFAULT_PREFETCH_THRESHOLD,
+        }
+    }
+}
+
+struct PooledSession {
+    session: Arc<Session>,
+    created_at: Instant,
+    #[allow(dead_code)]
+    pod_uid: String,
+}
+
+struct SessionPool {
+    entries: Vec<PooledSession>,
+    target_pod_uid: Option<String>,
+    prefetch_in_flight: bool,
+    opening_count: usize,
+}
+
+impl SessionPool {
+    fn new() -> Self {
+        Self {
+            entries: Vec::new(),
+            target_pod_uid: None,
+            prefetch_in_flight: false,
+            opening_count: 0,
+        }
+    }
+}
+
+/// Long-lived port-forward orchestrator. Construct via [`Forwarder::builder`].
+pub struct Forwarder {
+    pf_client: Arc<Client>,
+    namespace: Arc<str>,
+    pod_watcher: Arc<PodWatcher>,
+    sessions: Arc<TokioRwLock<SessionPool>>,
+    config: ForwarderConfig,
+    cancel: CancellationToken,
+    session_cancel: CancellationToken,
+    recovery_callback: RecoveryCallback,
+    portforward_semaphore: Arc<Semaphore>,
+    background_tasks: Arc<TokioMutex<JoinSet<()>>>,
+    call_counter: std::sync::atomic::AtomicU64,
+}
+
+impl Forwarder {
+    pub fn builder(
+        kube_client: kube::Client, cluster_url: http::Uri, namespace: impl Into<String>,
+    ) -> ForwarderBuilder {
+        ForwarderBuilder {
+            kube_client,
+            cluster_url,
+            namespace: namespace.into(),
+            selector: None,
+            config: ForwarderConfig::default(),
+            cancel: None,
+            recovery_callback: None,
+        }
+    }
+
+    /// Acquire a stream to the target pod's `target_port`. Waits up to 5s
+    /// for a ready pod on first call. Opens new sessions on demand and
+    /// retires drained ones.
+    pub async fn connect(&self, target_port: u16) -> Result<Stream, Error> {
+        for _ in 0..self.config.max_sessions {
+            let session = self.ensure_session(target_port).await?;
+            match session.connect().await {
+                Ok(s) => return Ok(s),
+                Err(Error::CapacityExhausted { .. }) => continue,
+                Err(e) => return Err(e),
+            }
+        }
+        Err(Error::CapacityExhausted {
+            in_use: 0,
+            capacity: self.config.max_sessions,
+        })
+    }
+
+    /// Cancellation token tripped by [`Forwarder::shutdown`].
+    pub fn cancellation_token(&self) -> CancellationToken {
+        self.cancel.clone()
+    }
+
+    pub fn ready_pod(&self) -> Option<String> {
+        self.pod_watcher.ready_pod().map(|p| p.name)
+    }
+
+    /// Cancel background tasks, drain all sessions.
+    pub async fn shutdown(self) -> Result<(), Error> {
+        self.pod_watcher.shutdown();
+        self.cancel.cancel();
+        self.session_cancel.cancel();
+        drain_and_cancel_all(&self.sessions).await;
+        let mut set = self.background_tasks.lock().await;
+        set.abort_all();
+        while let Some(result) = set.join_next().await {
+            match result {
+                Err(e) if e.is_panic() => {
+                    tracing::warn!("background task panicked during shutdown: {e}");
+                }
+                Err(e) if !e.is_cancelled() => {
+                    tracing::warn!("background task failed during shutdown: {e}");
+                }
+                _ => {}
+            }
+        }
+        Ok(())
+    }
+
+    async fn ensure_session(&self, target_port: u16) -> Result<Arc<Session>, Error> {
+        let call_id = self.next_call_id();
+        let t_total = Instant::now();
+        let t0 = Instant::now();
+        let ready = self
+            .pod_watcher
+            .wait_for_ready_pod(READY_POD_WAIT)
+            .await
+            .ok_or_else(|| Error::Configuration("no ready pod available".into()))?;
+        tracing::info!(
+            call_id,
+            elapsed_ms = t0.elapsed().as_millis() as u64,
+            "ensure_session: ready_pod resolved"
+        );
+        let pod_uid = ready.uid.clone().unwrap_or_else(|| ready.name.clone());
+
+        {
+            let mut pool = self.sessions.write().await;
+            if pool.target_pod_uid.as_deref() != Some(pod_uid.as_str()) {
+                let drained: Vec<_> = pool.entries.drain(..).collect();
+                pool.target_pod_uid = Some(pod_uid.clone());
+                drop(pool);
+                for pooled in drained {
+                    pooled.session.cancellation_token().cancel();
+                }
+            }
+        }
+
+        if let Some(s) = self
+            .try_reuse_session(target_port, &pod_uid, &ready.name)
+            .await
+        {
+            return Ok(s);
+        }
+
+        self.retire_dead_sessions().await;
+
+        if let Some(s) = self.find_reusable_session().await {
+            self.maybe_prefetch(&s, target_port, ready.name.clone(), pod_uid)
+                .await;
+            return Ok(s);
+        }
+
+        self.reserve_new_slot().await?;
+
+        let permit = tokio::time::timeout(
+            CONNECTION_SLOT_TIMEOUT,
+            self.portforward_semaphore.acquire(),
+        )
+        .await;
+        let _permit = match permit {
+            Ok(Ok(p)) => p,
+            Ok(Err(_)) => {
+                self.sessions.write().await.opening_count -= 1;
+                return Err(Error::Network("connection slot semaphore closed".into()));
+            }
+            Err(_) => {
+                self.sessions.write().await.opening_count -= 1;
+                return Err(Error::Network(
+                    "timed out waiting for connection slot".into(),
+                ));
+            }
+        };
+
+        let t_open = Instant::now();
+        let open_result = self.open_session(&ready.name, target_port).await;
+        tracing::info!(
+            call_id,
+            elapsed_ms = t_open.elapsed().as_millis() as u64,
+            outcome = if open_result.is_ok() { "ok" } else { "err" },
+            "ensure_session: open_session done"
+        );
+
+        let mut pool = self.sessions.write().await;
+        pool.opening_count -= 1;
+        let session = Arc::new(open_result?);
+        pool.entries.push(PooledSession {
+            session: Arc::clone(&session),
+            created_at: Instant::now(),
+            pod_uid: pod_uid.clone(),
+        });
+        if pool.target_pod_uid.is_none() {
+            pool.target_pod_uid = Some(pod_uid.clone());
+        }
+        drop(pool);
+        self.maybe_prefetch(&session, target_port, ready.name, pod_uid)
+            .await;
+        tracing::info!(
+            call_id,
+            elapsed_ms = t_total.elapsed().as_millis() as u64,
+            "ensure_session: total"
+        );
+        Ok(session)
+    }
+
+    /// Snapshot sessions under lock, drop the lock, then check `is_drained()`
+    /// on each. Re-acquire to swap in only alive sessions.
+    async fn retire_dead_sessions(&self) {
+        let snapshots: Vec<(Arc<Session>, bool)> = {
+            let pool = self.sessions.read().await;
+            pool.entries
+                .iter()
+                .map(|e| {
+                    (
+                        Arc::clone(&e.session),
+                        e.session.cancellation_token().is_cancelled(),
+                    )
+                })
+                .collect()
+        };
+
+        let mut dead_indices = Vec::new();
+        for (i, (session, cancelled)) in snapshots.iter().enumerate() {
+            if *cancelled || session.is_drained() {
+                dead_indices.push(i);
+            }
+        }
+
+        if dead_indices.is_empty() {
+            return;
+        }
+
+        let retired: Vec<Arc<Session>> = {
+            let mut write = self.sessions.write().await;
+            let mut retired_sessions = Vec::new();
+            let mut alive = Vec::with_capacity(write.entries.len());
+            for (i, entry) in write.entries.drain(..).enumerate() {
+                if dead_indices.contains(&i) {
+                    retired_sessions.push(Arc::clone(&entry.session));
+                } else {
+                    alive.push(entry);
+                }
+            }
+            write.entries = alive;
+            if write.entries.is_empty() {
+                write.target_pod_uid = None;
+            }
+            retired_sessions
+        };
+
+        for retired_session in retired {
+            retired_session.cancellation_token().cancel();
+        }
+    }
+
+    /// Snapshot non-cancelled session handles under write guard, drop it,
+    /// then check `is_full()` on each. Return first non-full session.
+    async fn find_reusable_session(&self) -> Option<Arc<Session>> {
+        let candidates: Vec<Arc<Session>> = {
+            let pool = self.sessions.read().await;
+            pool.entries
+                .iter()
+                .filter(|e| !e.session.cancellation_token().is_cancelled())
+                .map(|e| Arc::clone(&e.session))
+                .collect()
+        };
+
+        for session in candidates {
+            if !session.is_full() {
+                return Some(session);
+            }
+        }
+        None
+    }
+
+    /// Reserve a slot for a new session by incrementing `opening_count`.
+    async fn reserve_new_slot(&self) -> Result<(), Error> {
+        let mut pool = self.sessions.write().await;
+        let projected = pool.entries.len() + pool.opening_count;
+        if projected >= self.config.max_sessions {
+            return Err(Error::CapacityExhausted {
+                in_use: projected,
+                capacity: self.config.max_sessions,
+            });
+        }
+        pool.opening_count += 1;
+        Ok(())
+    }
+
+    fn next_call_id(&self) -> u64 {
+        self.call_counter
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Snapshot session handles under read guard, drop it, then check
+    /// `is_full()` on each outside the lock.
+    async fn try_reuse_session(
+        &self, target_port: u16, pod_uid: &str, pod_name: &str,
+    ) -> Option<Arc<Session>> {
+        let candidates: Vec<Arc<Session>> = {
+            let pool = self.sessions.read().await;
+            pool.entries
+                .iter()
+                .filter(|e| !e.session.cancellation_token().is_cancelled())
+                .map(|e| Arc::clone(&e.session))
+                .collect()
+        };
+
+        for session in candidates {
+            if !session.is_full() {
+                self.maybe_prefetch(
+                    &session,
+                    target_port,
+                    pod_name.to_string(),
+                    pod_uid.to_string(),
+                )
+                .await;
+                return Some(session);
+            }
+        }
+        None
+    }
+
+    async fn open_session(&self, pod_name: &str, port: u16) -> Result<Session, Error> {
+        let cb = Arc::clone(&self.recovery_callback);
+        self.pf_client
+            .session(&*self.namespace, pod_name, port)
+            .capacity(self.config.session_capacity)
+            .keepalive(self.config.keepalive.ping, self.config.keepalive.watchdog)
+            .shutdown_grace(self.config.shutdown_grace)
+            .cancellation_token(self.session_cancel.child_token())
+            .on_recovery(move |signal: RecoverySignal| (cb)(signal))
+            .open()
+            .await
+    }
+
+    async fn maybe_prefetch(
+        &self, session: &Arc<Session>, target_port: u16, pod_name: String, pod_uid: String,
+    ) {
+        let capacity = session.capacity();
+        if capacity == 0 {
+            return;
+        }
+        let in_use = session.in_use();
+        if (in_use as f32) < (capacity as f32) * self.config.prefetch_threshold {
+            return;
+        }
+
+        {
+            let mut pool = self.sessions.write().await;
+            if pool.prefetch_in_flight
+                || pool.entries.len() >= self.config.max_sessions
+                || pool.target_pod_uid.as_deref() != Some(pod_uid.as_str())
+            {
+                return;
+            }
+            pool.prefetch_in_flight = true;
+        }
+
+        let pf_client = Arc::clone(&self.pf_client);
+        let sessions = Arc::clone(&self.sessions);
+        let namespace = Arc::clone(&self.namespace);
+        let session_cancel = self.session_cancel.clone();
+        let config = self.config;
+        let recovery_cb = Arc::clone(&self.recovery_callback);
+
+        self.background_tasks.lock().await.spawn(async move {
+            debug!("forwarder: prefetching session for pod {}", pod_name);
+            let cb = Arc::clone(&recovery_cb);
+            let result = pf_client
+                .session(&*namespace, &pod_name, target_port)
+                .capacity(config.session_capacity)
+                .keepalive(config.keepalive.ping, config.keepalive.watchdog)
+                .shutdown_grace(config.shutdown_grace)
+                .cancellation_token(session_cancel.child_token())
+                .on_recovery(move |signal: RecoverySignal| (cb)(signal))
+                .open()
+                .await;
+
+            let mut pool = sessions.write().await;
+            pool.prefetch_in_flight = false;
+            match result {
+                Ok(new) => {
+                    let ok = pool.entries.len() < config.max_sessions
+                        && pool.target_pod_uid.as_deref() == Some(pod_uid.as_str());
+                    if ok {
+                        pool.entries.push(PooledSession {
+                            session: Arc::new(new),
+                            created_at: Instant::now(),
+                            pod_uid: pod_uid.clone(),
+                        });
+                    } else {
+                        drop(pool);
+                        new.cancellation_token().cancel();
+                    }
+                }
+                Err(e) => debug!("forwarder: prefetch failed: {}", e),
+            }
+        });
+    }
+
+    async fn spawn_prune(&self) {
+        let sessions = Arc::clone(&self.sessions);
+        let cancel = self.cancel.clone();
+        let interval_dur = self.config.prune_interval;
+        let idle_age = self.config.prune_idle_age;
+        self.background_tasks.lock().await.spawn(async move {
+            let mut interval = tokio::time::interval(interval_dur);
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            interval.tick().await;
+            loop {
+                tokio::select! {
+                    biased;
+                    _ = cancel.cancelled() => break,
+                    _ = interval.tick() => {
+                        prune_once(&sessions, idle_age).await;
+                    }
+                }
+            }
+        });
+    }
+
+    async fn spawn_pod_change_reactor(&self) {
+        let mut rx = self.pod_watcher.subscribe();
+        let sessions = Arc::clone(&self.sessions);
+        let cancel = self.cancel.clone();
+        let recovery_cb = Arc::clone(&self.recovery_callback);
+        self.background_tasks.lock().await.spawn(async move {
+            loop {
+                tokio::select! {
+                    biased;
+                    _ = cancel.cancelled() => break,
+                    ev = rx.recv() => match ev {
+                        Ok(PodChange::Died(name)) => {
+                            debug!("forwarder: pod {} died, draining sessions", name);
+                            drain_and_cancel_all(&sessions).await;
+                            (recovery_cb)(RecoverySignal::ServerClose);
+                        }
+                        Ok(PodChange::Ready(_)) => {}
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {}
+                        Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                    }
+                }
+            }
+        });
+    }
+}
+
+/// Snapshot session handles + metadata under write guard, drop it, then
+/// check `in_use()` on each outside the lock. Re-acquire to remove idle
+/// entries.
+async fn prune_once(sessions: &Arc<TokioRwLock<SessionPool>>, idle_age: Duration) {
+    let snapshots: Vec<(Arc<Session>, Instant, bool)> = {
+        let pool = sessions.read().await;
+        if pool.entries.is_empty() {
+            return;
+        }
+        pool.entries
+            .iter()
+            .map(|e| {
+                (
+                    Arc::clone(&e.session),
+                    e.created_at,
+                    e.session.cancellation_token().is_cancelled(),
+                )
+            })
+            .collect()
+    };
+
+    let total = snapshots.len();
+    let mut idle_indices = Vec::new();
+    for (i, (session, created_at, cancelled)) in snapshots.iter().enumerate() {
+        let aged_idle = session.in_use() == 0 && created_at.elapsed() > idle_age;
+        if *cancelled || aged_idle {
+            idle_indices.push(i);
+        }
+    }
+
+    let to_prune = if total > 1 {
+        idle_indices.len().min(total - 1)
+    } else {
+        0
+    };
+    if to_prune == 0 {
+        return;
+    }
+
+    let mut pool = sessions.write().await;
+    // Re-check: pool may have changed while we were checking in_use()
+    if pool.entries.len() != total {
+        return;
+    }
+    let prune_set: std::collections::HashSet<usize> =
+        idle_indices.into_iter().take(to_prune).collect();
+    let mut dropped = Vec::with_capacity(to_prune);
+    let mut kept = Vec::with_capacity(total - to_prune);
+    for (i, entry) in pool.entries.drain(..).enumerate() {
+        if prune_set.contains(&i) {
+            dropped.push(entry);
+        } else {
+            kept.push(entry);
+        }
+    }
+    pool.entries = kept;
+    drop(pool);
+    for dropped_session in dropped {
+        dropped_session.session.cancellation_token().cancel();
+    }
+}
+
+/// Builder for [`Forwarder`].
+pub struct ForwarderBuilder {
+    kube_client: kube::Client,
+    cluster_url: http::Uri,
+    namespace: String,
+    selector: Option<PodSelector>,
+    config: ForwarderConfig,
+    cancel: Option<CancellationToken>,
+    recovery_callback: Option<RecoveryCallback>,
+}
+
+impl ForwarderBuilder {
+    pub fn pod_selector(mut self, sel: PodSelector) -> Self {
+        self.selector = Some(sel);
+        self
+    }
+
+    pub fn max_sessions(mut self, n: usize) -> Self {
+        self.config.max_sessions = n;
+        self
+    }
+
+    pub fn session_capacity(mut self, n: usize) -> Self {
+        self.config.session_capacity = n;
+        self
+    }
+
+    pub fn keepalive(mut self, ping: Duration, watchdog: Duration) -> Self {
+        self.config.keepalive = KeepaliveConfig { ping, watchdog };
+        self
+    }
+
+    pub fn shutdown_grace(mut self, drain: Duration) -> Self {
+        self.config.shutdown_grace = drain;
+        self
+    }
+
+    pub fn prune(mut self, interval: Duration, idle_age: Duration) -> Self {
+        self.config.prune_interval = interval;
+        self.config.prune_idle_age = idle_age;
+        self
+    }
+
+    pub fn prefetch_threshold(mut self, ratio: f32) -> Self {
+        self.config.prefetch_threshold = ratio.clamp(0.0, 1.0);
+        self
+    }
+
+    pub fn cancellation_token(mut self, t: CancellationToken) -> Self {
+        self.cancel = Some(t);
+        self
+    }
+
+    pub fn on_recovery<F>(mut self, cb: F) -> Self
+    where
+        F: Fn(RecoverySignal) + Send + Sync + 'static,
+    {
+        self.recovery_callback = Some(Arc::new(cb));
+        self
+    }
+
+    pub async fn build(self) -> Result<Forwarder, Error> {
+        if self.config.max_sessions == 0 {
+            return Err(Error::Configuration("max_sessions must be > 0".into()));
+        }
+        if self.config.session_capacity == 0 {
+            return Err(Error::Configuration("session_capacity must be > 0".into()));
+        }
+        let selector = self
+            .selector
+            .ok_or_else(|| Error::Configuration("pod_selector is required".into()))?;
+        let pod_watcher =
+            Arc::new(PodWatcher::new(self.kube_client.clone(), &self.namespace, selector).await?);
+        let pf_client = Arc::new(Client::new(self.kube_client, self.cluster_url));
+        let cancel = self.cancel.unwrap_or_default();
+        let recovery_callback: RecoveryCallback =
+            self.recovery_callback.unwrap_or_else(|| Arc::new(|_| {}));
+
+        let forwarder = Forwarder {
+            pf_client,
+            namespace: Arc::from(self.namespace),
+            pod_watcher,
+            sessions: Arc::new(TokioRwLock::new(SessionPool::new())),
+            config: self.config,
+            cancel,
+            session_cancel: CancellationToken::new(),
+            recovery_callback,
+            portforward_semaphore: Arc::new(Semaphore::new(CONNECTION_SLOT_PERMITS)),
+            background_tasks: Arc::new(TokioMutex::new(JoinSet::new())),
+            call_counter: std::sync::atomic::AtomicU64::new(0),
+        };
+        forwarder.spawn_prune().await;
+        forwarder.spawn_pod_change_reactor().await;
+        Ok(forwarder)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config_sane() {
+        let c = ForwarderConfig::default();
+        assert_eq!(c.max_sessions, 128);
+        assert_eq!(c.session_capacity, 1);
+        assert!(c.prefetch_threshold > 0.0 && c.prefetch_threshold < 1.0);
+    }
+}

--- a/crates/kube-portforward/src/frame.rs
+++ b/crates/kube-portforward/src/frame.rs
@@ -1,0 +1,99 @@
+use bytes::{
+    BufMut,
+    Bytes,
+    BytesMut,
+};
+
+use crate::error::Error;
+
+pub(crate) const CLOSE_SIGNAL_BYTE: u8 = 0xFF;
+
+pub(crate) fn encode_channel_frame(channel: u8, payload: &[u8]) -> Bytes {
+    let mut buf = BytesMut::with_capacity(1 + payload.len());
+    buf.put_u8(channel);
+    buf.put_slice(payload);
+    buf.freeze()
+}
+
+pub(crate) fn encode_close_signal(channel: u8) -> Bytes {
+    let mut buf = BytesMut::with_capacity(2);
+    buf.put_u8(CLOSE_SIGNAL_BYTE);
+    buf.put_u8(channel);
+    buf.freeze()
+}
+
+pub(crate) fn split_channel_byte(mut payload: Bytes) -> Result<(u8, Bytes), Error> {
+    if payload.is_empty() {
+        return Err(Error::ProtocolViolation {
+            context: "split_channel_byte",
+            detail: "empty frame".into(),
+        });
+    }
+    let channel = payload.split_to(1)[0];
+    Ok((channel, payload))
+}
+
+pub(crate) fn parse_close_signal(payload: &Bytes) -> Option<u8> {
+    if payload.len() == 2 && payload[0] == CLOSE_SIGNAL_BYTE {
+        Some(payload[1])
+    } else {
+        None
+    }
+}
+
+pub(crate) fn parse_initial_port_frame(payload: &Bytes) -> Result<u16, Error> {
+    if payload.len() < 2 {
+        return Err(Error::ProtocolViolation {
+            context: "parse_initial_port_frame",
+            detail: format!("expected 2 bytes, got {}", payload.len()),
+        });
+    }
+    Ok(u16::from_le_bytes([payload[0], payload[1]]))
+}
+
+pub(crate) fn bytes_to_message(payload: Bytes) -> tungstenite::Message {
+    tungstenite::Message::Binary(payload)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip_channel_frame() {
+        let payload = b"hello world";
+        let encoded = encode_channel_frame(7, payload);
+        let (ch, body) = split_channel_byte(encoded).expect("split");
+        assert_eq!(ch, 7);
+        assert_eq!(&body[..], payload);
+    }
+
+    #[test]
+    fn close_signal_round_trip() {
+        let encoded = encode_close_signal(42);
+        assert_eq!(parse_close_signal(&encoded), Some(42));
+    }
+
+    #[test]
+    fn close_signal_does_not_match_normal_frame() {
+        let encoded = encode_channel_frame(0xFF, &[1, 2, 3]);
+        assert_eq!(parse_close_signal(&encoded), None);
+    }
+
+    #[test]
+    fn split_empty_errors() {
+        assert!(split_channel_byte(Bytes::new()).is_err());
+    }
+
+    #[test]
+    fn initial_port_frame_parses_le() {
+        let bytes = Bytes::from_static(&[0xF0, 0x23]);
+        assert_eq!(parse_initial_port_frame(&bytes).unwrap(), 0x23F0);
+    }
+
+    #[test]
+    fn initial_port_frame_short_errors() {
+        let bytes = Bytes::from_static(&[0x01]);
+        assert!(parse_initial_port_frame(&bytes).is_err());
+    }
+}

--- a/crates/kube-portforward/src/keepalive.rs
+++ b/crates/kube-portforward/src/keepalive.rs
@@ -1,0 +1,152 @@
+use std::sync::Arc;
+use std::sync::atomic::{
+    AtomicI64,
+    Ordering,
+};
+use std::time::{
+    Duration,
+    SystemTime,
+    UNIX_EPOCH,
+};
+
+use bytes::Bytes;
+use tokio::sync::mpsc;
+use tokio::task::JoinSet;
+use tokio::time::{
+    MissedTickBehavior,
+    interval,
+};
+use tokio_util::sync::CancellationToken;
+use tungstenite::Message;
+
+use crate::error::Error;
+
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum RecoverySignal {
+    KeepaliveTimeout {
+        last_pong_age: Duration,
+    },
+    ServerClose,
+    NetworkError(String),
+    UpgradeFailed {
+        status: Option<u16>,
+        message: String,
+    },
+}
+
+/// User-supplied callback invoked on recovery-worthy events. Implementations
+/// must be cheap (typically a channel send) — they run on the keepalive /
+/// reader tasks.
+///
+/// This uses `Arc<dyn Fn>` for simplicity. A trait-based approach (e.g.
+/// `trait RecoveryHandler`) would allow richer extensibility (async callbacks,
+/// typed returns) but would complicate the builder API for minimal gain
+/// in the current use cases.
+pub type RecoveryCallback = Arc<dyn Fn(RecoverySignal) + Send + Sync>;
+
+const WATCHDOG_INTERVAL: Duration = Duration::from_secs(5);
+
+#[derive(Clone)]
+pub(crate) struct KeepaliveHandle {
+    last_pong: Arc<AtomicI64>,
+    cancel: CancellationToken,
+}
+
+impl KeepaliveHandle {
+    pub(crate) fn note_pong(&self) {
+        self.last_pong.store(now_ms(), Ordering::Relaxed);
+    }
+
+    pub(crate) fn arm(&self) {
+        self.last_pong.store(now_ms(), Ordering::Relaxed);
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn last_pong_age(&self) -> Duration {
+        let last = self.last_pong.load(Ordering::Relaxed);
+        if last == i64::MAX {
+            return Duration::ZERO;
+        }
+        let delta = now_ms().saturating_sub(last);
+        Duration::from_millis(u64::try_from(delta).unwrap_or(0))
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn cancel_token(&self) -> CancellationToken {
+        self.cancel.clone()
+    }
+}
+
+pub(crate) fn spawn_keepalive(
+    writer_mailbox: mpsc::Sender<Message>, cancel: CancellationToken,
+    recovery_callback: RecoveryCallback, ping_interval: Duration, watchdog_timeout: Duration,
+    join_set: &mut JoinSet<Result<(), Error>>,
+) -> KeepaliveHandle {
+    let last_pong = Arc::new(AtomicI64::new(i64::MAX));
+
+    let heartbeat_cancel = cancel.clone();
+    let heartbeat_writer = writer_mailbox.clone();
+    join_set.spawn(async move {
+        let mut ticker = interval(ping_interval);
+        ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
+        loop {
+            tokio::select! {
+                biased;
+                _ = heartbeat_cancel.cancelled() => return Ok(()),
+                _ = ticker.tick() => {
+                    tracing::debug!("WebSocket keepalive heartbeat tick");
+                    if heartbeat_writer
+                        .send(Message::Ping(Bytes::new()))
+                        .await
+                        .is_err()
+                    {
+                        return Ok(());
+                    }
+                }
+            }
+        }
+    });
+
+    let watchdog_cancel = cancel.clone();
+    let watchdog_pong = Arc::clone(&last_pong);
+    let watchdog_cb = Arc::clone(&recovery_callback);
+    let watchdog_threshold_ms = i64::try_from(watchdog_timeout.as_millis()).unwrap_or(i64::MAX);
+    join_set.spawn(async move {
+        let mut ticker = interval(WATCHDOG_INTERVAL);
+        ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
+        loop {
+            tokio::select! {
+                biased;
+                _ = watchdog_cancel.cancelled() => return Ok(()),
+                _ = ticker.tick() => {
+                    let last = watchdog_pong.load(Ordering::Relaxed);
+                    if last == i64::MAX {
+                        continue;
+                    }
+                    let elapsed = now_ms().saturating_sub(last);
+                    if elapsed > watchdog_threshold_ms {
+                        let age = Duration::from_millis(u64::try_from(elapsed).unwrap_or(0));
+                        watchdog_cb(RecoverySignal::KeepaliveTimeout { last_pong_age: age });
+                        watchdog_cancel.cancel();
+                        tracing::warn!(
+                            elapsed_ms = elapsed,
+                            "WebSocket keepalive timed out: no Pong received within threshold"
+                        );
+                        return Ok(());
+                    }
+                }
+            }
+        }
+    });
+
+    KeepaliveHandle { last_pong, cancel }
+}
+
+fn now_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .and_then(|d| i64::try_from(d.as_millis()).ok())
+        .unwrap_or(i64::MAX)
+}

--- a/crates/kube-portforward/src/lib.rs
+++ b/crates/kube-portforward/src/lib.rs
@@ -1,0 +1,101 @@
+//! Kubernetes port-forward over WebSocket with channel multiplexing.
+//!
+//! Speaks `v5.channel.k8s.io` (preferred) and `v4.channel.k8s.io` (fallback)
+//! per [KEP-4006](https://github.com/kubernetes/enhancements/issues/4006).
+//! Multiplexes N concurrent local TCP connections over ONE WebSocket upgrade
+//! by encoding the target pod port N times in the URL.
+//!
+//! ## Channel lifecycle
+//!
+//! Channel pairs are **one-shot**: the apiserver binds each pair to a single
+//! backend pod connection at upgrade time, so an ID pair cannot be reused for
+//! a fresh connection after either side has sent the v5 `[0xFF, channel]`
+//! close signal. The allocator therefore decrements live-count on release
+//! but never returns IDs to the free-list.
+//!
+//! ## CLOSE_WAIT and v4 limitation
+//!
+//! On v5, `AsyncWrite::shutdown()` (and dropping a [`Stream`]) emits `0xFF`
+//! to the apiserver, which tears down the pod-side connection and echoes
+//! `0xFF` back. The reader translates that into EOF on the read half, so a
+//! client like `kftray-portforward`'s `forward_streams` can finish copying
+//! and drop its local socket, avoiding CLOSE_WAIT accumulation.
+//!
+//! On v4 there is no half-close frame, so once the local writer closes the
+//! pod-side connection cannot be signalled to drain; CLOSE_WAIT on v4 is
+//! unfixable from the client layer. v4 is the rare fallback for pre-1.30
+//! clusters (see KEP-4006).
+//!
+//! ## Why not [`kube::Api::portforward`]?
+//!
+//! `kube::Api::portforward` opens a new WebSocket upgrade for every stream
+//! pair, lacks keepalive, and surfaces opaque errors. This crate multiplexes
+//! up to 64 stream pairs per upgrade, runs a Ping/Pong watchdog, exposes
+//! structured `thiserror` errors, and detects pre-1.30 clusters with a
+//! KEP-4006-citing error.
+//!
+//! ## Quick Start
+//!
+//! ```no_run
+//! use kube_portforward::Client;
+//! use tokio::io::AsyncWriteExt;
+//!
+//! # async fn run(kube: kube::Client, url: http::Uri) -> Result<(), Box<dyn std::error::Error>> {
+//! let client = Client::new(kube, url);
+//! let session = client.session("default", "nginx", 80).open().await?;
+//! let mut stream = session.connect().await?;
+//! stream.write_all(b"GET / HTTP/1.0\r\n\r\n").await?;
+//! session.close().await?;
+//! # Ok(()) }
+//! ```
+
+pub(crate) mod allocator;
+pub(crate) mod client;
+pub(crate) mod connect;
+pub(crate) mod error;
+pub(crate) mod forwarder;
+pub(crate) mod frame;
+pub(crate) mod keepalive;
+pub(crate) mod pod_watch;
+pub(crate) mod reader;
+pub(crate) mod routing;
+pub(crate) mod session;
+pub(crate) mod shutdown;
+pub(crate) mod stream;
+pub(crate) mod subprotocol;
+pub(crate) mod version;
+pub(crate) mod writer;
+
+pub use client::{
+    Client,
+    ClientBuilder,
+    SessionBuilder,
+};
+pub use error::Error;
+pub use forwarder::{
+    Forwarder,
+    ForwarderBuilder,
+};
+pub use keepalive::{
+    RecoveryCallback,
+    RecoverySignal,
+};
+pub use pod_watch::{
+    PodChange,
+    PodSelector,
+    PodWatcher,
+    ReadyPod,
+};
+pub use session::Session;
+pub use stream::{
+    DataStream,
+    ErrorStream,
+    Stream,
+};
+pub use subprotocol::Subprotocol;
+pub use version::VersionInfo;
+#[cfg(feature = "version-cache")]
+pub use version::{
+    VersionCache,
+    global_version_cache,
+};

--- a/crates/kube-portforward/src/pod_watch.rs
+++ b/crates/kube-portforward/src/pod_watch.rs
@@ -1,0 +1,416 @@
+//! Generic Kubernetes pod watcher.
+//!
+//! Tracks pod readiness in a namespace using `kube_runtime::reflector` and
+//! resolves a [`PodSelector`] (label expression or pod name) to a currently
+//! ready pod. Lifecycle events are broadcast on a [`tokio::sync::broadcast`]
+//! channel as [`PodChange`].
+//!
+//! This module is intentionally kftray-agnostic — it knows nothing about
+//! services, workload types, or any higher-level configuration.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use arc_swap::ArcSwapOption;
+use futures::StreamExt;
+use k8s_openapi::api::core::v1::Pod;
+use kube::{
+    Api,
+    ResourceExt,
+};
+use kube_runtime::{
+    WatchStreamExt,
+    reflector::{
+        self,
+        ReflectHandle,
+        Store,
+    },
+    watcher::{
+        self,
+        Config as WatcherConfig,
+    },
+};
+use tokio::sync::broadcast;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+use tracing::{
+    debug,
+    error,
+};
+
+use crate::error::Error;
+
+/// Pod selection strategy.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum PodSelector {
+    /// Match a single pod by exact name.
+    Name(String),
+    /// Match pods by a Kubernetes label selector expression
+    /// (e.g. `app=nginx,tier=frontend`).
+    Labels { selector: String },
+}
+
+/// Pod lifecycle change broadcast to subscribers.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum PodChange {
+    /// A pod matching the selector became ready (or replaced a previously
+    /// ready pod). Carries the new pod name.
+    Ready(String),
+    /// The previously ready pod was deleted. Carries the dead pod name.
+    Died(String),
+}
+
+/// Snapshot of the currently ready pod.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct ReadyPod {
+    pub name: String,
+    pub uid: Option<String>,
+}
+
+impl ReadyPod {
+    /// Create a new `ReadyPod` snapshot.
+    pub fn new(name: String, uid: Option<String>) -> Self {
+        Self { name, uid }
+    }
+}
+
+/// Watches pods in a namespace and tracks the currently ready pod matching
+/// a [`PodSelector`]. Owns a background reflector task that is aborted on
+/// [`PodWatcher::shutdown`].
+pub struct PodWatcher {
+    store: Store<Pod>,
+    _subscriber: ReflectHandle<Pod>,
+    latest_ready: Arc<ArcSwapOption<ReadyPod>>,
+    change_tx: broadcast::Sender<PodChange>,
+    selector: PodSelector,
+    reflector_task: JoinHandle<()>,
+    subscriber_task: JoinHandle<()>,
+    cancel: CancellationToken,
+}
+
+impl Drop for PodWatcher {
+    fn drop(&mut self) {
+        self.cancel.cancel();
+        self.reflector_task.abort();
+        self.subscriber_task.abort();
+    }
+}
+
+impl PodWatcher {
+    /// Start a watcher against `namespace` selecting pods by `selector`.
+    pub async fn new(
+        client: kube::Client, namespace: &str, selector: PodSelector,
+    ) -> Result<Self, Error> {
+        let label_expr = match &selector {
+            PodSelector::Labels { selector } => selector.clone(),
+            PodSelector::Name(_) => String::new(),
+        };
+
+        let (store, writer) = reflector::store_shared(256);
+        let subscriber = writer.subscribe().ok_or_else(|| {
+            Error::Configuration("failed to create pod reflector subscriber".into())
+        })?;
+
+        let cancel = CancellationToken::new();
+        let latest_ready: Arc<ArcSwapOption<ReadyPod>> = Arc::new(ArcSwapOption::const_empty());
+        let (change_tx, _) = broadcast::channel(16);
+
+        let pods_api: Api<Pod> = Api::namespaced(client, namespace);
+        let watcher_config = if label_expr.is_empty() {
+            WatcherConfig::default()
+        } else {
+            WatcherConfig::default().labels(&label_expr)
+        };
+
+        let reflector_cancel = cancel.clone();
+        let reflector_latest = Arc::clone(&latest_ready);
+        let reflector_change_tx = change_tx.clone();
+        let reflector_task = tokio::spawn(async move {
+            let stream = watcher::watcher(pods_api, watcher_config)
+                .default_backoff()
+                .modify(|pod| {
+                    pod.managed_fields_mut().clear();
+                    pod.annotations_mut().clear();
+                    if let Some(status) = &mut pod.status {
+                        status.container_statuses = None;
+                        status.init_container_statuses = None;
+                        status.ephemeral_container_statuses = None;
+                    }
+                })
+                .reflect_shared(writer);
+
+            let mut stream = std::pin::pin!(stream);
+            loop {
+                tokio::select! {
+                    biased;
+                    _ = reflector_cancel.cancelled() => break,
+                    next = stream.next() => match next {
+                        Some(Ok(watcher::Event::Delete(pod))) => {
+                            let name = pod.name_any();
+                            let prev = reflector_latest.rcu(|cur| {
+                                if cur.as_deref().is_some_and(|c| c.name == name) {
+                                    None
+                                } else {
+                                    cur.clone()
+                                }
+                            });
+                            if prev.as_deref().is_some_and(|c| c.name == name) {
+                                let _ = reflector_change_tx.send(PodChange::Died(name));
+                            }
+                        }
+                        Some(Ok(_)) => {}
+                        Some(Err(e)) => {
+                            error!("pod reflector error: {}", e);
+                            tokio::select! {
+                                biased;
+                                _ = reflector_cancel.cancelled() => break,
+                                _ = tokio::time::sleep(Duration::from_secs(1)) => {}
+                            }
+                        }
+                        None => break,
+                    },
+                }
+            }
+        });
+
+        let subscriber_cancel = cancel.clone();
+        let subscriber_latest = Arc::clone(&latest_ready);
+        let subscriber_change_tx = change_tx.clone();
+        let subscriber_selector = selector.clone();
+        let subscriber_handle = subscriber.clone();
+        let subscriber_task = tokio::spawn(async move {
+            let mut stream = std::pin::pin!(subscriber_handle);
+            loop {
+                tokio::select! {
+                    biased;
+                    _ = subscriber_cancel.cancelled() => break,
+                    next = stream.next() => match next {
+                        Some(pod) => {
+                            update_latest(
+                                &subscriber_latest,
+                                &pod,
+                                &subscriber_selector,
+                                &subscriber_change_tx,
+                            );
+                        }
+                        None => break,
+                    },
+                }
+            }
+        });
+
+        Ok(Self {
+            store,
+            _subscriber: subscriber,
+            latest_ready,
+            change_tx,
+            selector,
+            reflector_task,
+            subscriber_task,
+            cancel,
+        })
+    }
+
+    /// Returns the currently ready pod, if any. Single scan of the store.
+    pub fn ready_pod(&self) -> Option<ReadyPod> {
+        let cached = self.latest_ready.load_full();
+        let mut first_ready: Option<ReadyPod> = None;
+
+        for pod in self.store.state() {
+            if !is_pod_ready(&pod, &self.selector) {
+                continue;
+            }
+            // If the cached pod is still ready, return it directly
+            if let Some(ref c) = cached {
+                if pod.name_any() == c.name {
+                    return Some((**c).clone());
+                }
+            }
+            // Track first ready pod as fallback
+            if first_ready.is_none() {
+                first_ready = Some(ReadyPod {
+                    name: pod.name_any(),
+                    uid: pod.metadata.uid.clone(),
+                });
+            }
+        }
+
+        match first_ready {
+            Some(ready) => {
+                self.latest_ready.store(Some(Arc::new(ready.clone())));
+                Some(ready)
+            }
+            None => {
+                self.latest_ready.store(None);
+                None
+            }
+        }
+    }
+
+    /// Wait until a ready pod is available or `timeout` elapses.
+    /// Wakes on `PodChange` events instead of polling.
+    pub async fn wait_for_ready_pod(&self, timeout: Duration) -> Option<ReadyPod> {
+        if let Some(pod) = self.ready_pod() {
+            return Some(pod);
+        }
+
+        let mut rx = self.subscribe();
+        let deadline = tokio::time::sleep(timeout);
+        tokio::pin!(deadline);
+
+        loop {
+            tokio::select! {
+                biased;
+                _ = &mut deadline => return None,
+                ev = rx.recv() => {
+                    match ev {
+                        Ok(PodChange::Ready(_)) => {
+                            if let Some(pod) = self.ready_pod() {
+                                return Some(pod);
+                            }
+                        }
+                        Err(broadcast::error::RecvError::Closed) => return None,
+                        _ => {}
+                    }
+                }
+            }
+        }
+    }
+
+    /// Subscribe to pod lifecycle events. Each new subscriber sees only
+    /// events emitted after the subscription.
+    pub fn subscribe(&self) -> broadcast::Receiver<PodChange> {
+        self.change_tx.subscribe()
+    }
+
+    /// Cancel background tasks. Idempotent.
+    pub fn shutdown(&self) {
+        self.cancel.cancel();
+    }
+}
+
+fn update_latest(
+    latest: &Arc<ArcSwapOption<ReadyPod>>, pod: &Pod, selector: &PodSelector,
+    change_tx: &broadcast::Sender<PodChange>,
+) {
+    if !is_pod_ready(pod, selector) {
+        return;
+    }
+
+    let name = pod.name_any();
+
+    // Check whether the pod actually changed before allocating
+    let prev = latest.load();
+    let changed = match prev.as_deref() {
+        Some(cur) => cur.name != name,
+        None => true,
+    };
+
+    if changed {
+        let ready = Arc::new(ReadyPod {
+            name: name.clone(),
+            uid: pod.metadata.uid.clone(),
+        });
+        latest.store(Some(ready));
+        debug!("pod_watch: ready pod changed to {}", name);
+        let _ = change_tx.send(PodChange::Ready(name));
+    }
+}
+
+fn matches_selector(pod: &Pod, selector: &PodSelector) -> bool {
+    match selector {
+        PodSelector::Name(name) => pod.name_any() == *name,
+        PodSelector::Labels { .. } => true,
+    }
+}
+
+fn is_pod_ready(pod: &Pod, selector: &PodSelector) -> bool {
+    if !matches_selector(pod, selector) {
+        return false;
+    }
+    let Some(status) = pod.status.as_ref() else {
+        return false;
+    };
+    let running = status.phase.as_deref() == Some("Running");
+    if !running {
+        return false;
+    }
+    status
+        .conditions
+        .as_ref()
+        .map(|cs| cs.iter().any(|c| c.type_ == "Ready" && c.status == "True"))
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use k8s_openapi::api::core::v1::{
+        PodCondition,
+        PodStatus,
+    };
+    use kube::api::ObjectMeta;
+
+    use super::*;
+
+    fn mk_pod(name: &str, ready: bool, running: bool) -> Pod {
+        Pod {
+            metadata: ObjectMeta {
+                name: Some(name.to_string()),
+                ..Default::default()
+            },
+            status: Some(PodStatus {
+                phase: Some(if running { "Running" } else { "Pending" }.to_string()),
+                conditions: Some(vec![PodCondition {
+                    type_: "Ready".into(),
+                    status: if ready { "True" } else { "False" }.into(),
+                    ..Default::default()
+                }]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn ready_running_pod_is_ready_for_labels_selector() {
+        let pod = mk_pod("p1", true, true);
+        assert!(is_pod_ready(
+            &pod,
+            &PodSelector::Labels {
+                selector: "app=x".into()
+            }
+        ));
+    }
+
+    #[test]
+    fn not_running_pod_is_not_ready() {
+        let pod = mk_pod("p1", true, false);
+        assert!(!is_pod_ready(
+            &pod,
+            &PodSelector::Labels {
+                selector: String::new()
+            }
+        ));
+    }
+
+    #[test]
+    fn name_selector_filters_by_name() {
+        let pod = mk_pod("p1", true, true);
+        assert!(is_pod_ready(&pod, &PodSelector::Name("p1".into())));
+        assert!(!is_pod_ready(&pod, &PodSelector::Name("p2".into())));
+    }
+
+    #[test]
+    fn ready_condition_must_be_true() {
+        let pod = mk_pod("p1", false, true);
+        assert!(!is_pod_ready(
+            &pod,
+            &PodSelector::Labels {
+                selector: String::new()
+            }
+        ));
+    }
+}

--- a/crates/kube-portforward/src/reader.rs
+++ b/crates/kube-portforward/src/reader.rs
@@ -1,0 +1,89 @@
+use futures::StreamExt;
+use futures::stream::SplitStream;
+use hyper::upgrade::Upgraded;
+use hyper_util::rt::TokioIo;
+use tokio::sync::mpsc;
+use tokio::task::JoinSet;
+use tokio_tungstenite::WebSocketStream;
+use tokio_util::sync::CancellationToken;
+use tungstenite::Message;
+
+use crate::error::Error;
+use crate::frame;
+use crate::keepalive::{
+    KeepaliveHandle,
+    RecoveryCallback,
+    RecoverySignal,
+};
+use crate::routing::Router;
+use crate::subprotocol::Subprotocol;
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn spawn_reader(
+    subprotocol: Subprotocol, stream: SplitStream<WebSocketStream<TokioIo<Upgraded>>>,
+    router: Router, writer_mailbox: mpsc::Sender<Message>, cancel: CancellationToken,
+    keepalive: KeepaliveHandle, recovery_callback: RecoveryCallback,
+    join_set: &mut JoinSet<Result<(), Error>>,
+) {
+    join_set.spawn(async move {
+        let mut stream = stream;
+        keepalive.arm();
+        loop {
+            tokio::select! {
+                biased;
+                _ = cancel.cancelled() => return Ok(()),
+                maybe_msg = stream.next() => {
+                    match maybe_msg {
+                        None => return Ok(()),
+                        Some(Err(e)) => {
+                            tracing::warn!(?subprotocol, "reader: WS stream error: {}", e);
+                            // Note: tungstenite::Error is flattened to String because
+                            // RecoverySignal::NetworkError carries String. Changing this
+                            // would require RecoverySignal to carry a boxed error source.
+                            recovery_callback(RecoverySignal::NetworkError(e.to_string()));
+                            cancel.cancel();
+                            return Ok(());
+                        }
+                        Some(Ok(Message::Binary(payload))) => {
+                            if subprotocol == Subprotocol::V5
+                                && let Some(closed_channel) = frame::parse_close_signal(&payload)
+                            {
+                                tracing::debug!("v5 reader: server CLOSE on channel {}", closed_channel);
+                                router.remove(closed_channel);
+                                continue;
+                            }
+                            keepalive.note_pong();
+                            match frame::split_channel_byte(payload) {
+                                Ok((channel, body)) => {
+                                    router.dispatch(channel, body).await;
+                                }
+                                Err(e) => {
+                                    tracing::warn!(?subprotocol, "reader: invalid frame: {}", e);
+                                }
+                            }
+                        }
+                        Some(Ok(Message::Ping(p))) => {
+                            tokio::select! {
+                                _ = writer_mailbox.send(Message::Pong(p)) => {}
+                                _ = cancel.cancelled() => return Ok(()),
+                            }
+                        }
+                        Some(Ok(Message::Pong(_))) => {
+                            keepalive.note_pong();
+                        }
+                        Some(Ok(Message::Close(_))) => {
+                            tracing::debug!(?subprotocol, "reader: server sent Close");
+                            recovery_callback(RecoverySignal::ServerClose);
+                            cancel.cancel();
+                            return Ok(());
+                        }
+                        Some(Ok(Message::Text(_))) => {
+                            tracing::warn!(?subprotocol, "reader: unexpected Text frame; ignoring");
+                        }
+                        Some(Ok(Message::Frame(_))) => {}
+                    }
+                }
+            }
+        }
+    });
+}

--- a/crates/kube-portforward/src/routing.rs
+++ b/crates/kube-portforward/src/routing.rs
@@ -1,0 +1,137 @@
+use std::sync::Arc;
+
+use bytes::Bytes;
+use parking_lot::RwLock;
+use tokio::sync::mpsc;
+
+use crate::frame;
+
+const ROUTER_CAPACITY: usize = 256;
+
+#[derive(Clone)]
+pub(crate) struct Router {
+    // Channel IDs are u8 → exactly 256 slots. Direct indexing avoids the
+    // hashing/sharding overhead present in DashMap.
+    slots: Arc<[RwLock<Option<ChannelEntry>>; ROUTER_CAPACITY]>,
+}
+
+struct ChannelEntry {
+    sender: mpsc::Sender<Bytes>,
+    port_seen: bool,
+}
+
+impl Router {
+    pub(crate) fn new() -> Self {
+        let slots: [RwLock<Option<ChannelEntry>>; ROUTER_CAPACITY] =
+            std::array::from_fn(|_| RwLock::new(None));
+        Self {
+            slots: Arc::new(slots),
+        }
+    }
+
+    /// Insert (or replace) a channel entry. Preserves `port_seen=true` on
+    /// existing entries so a channel pre-registered at handshake (and whose
+    /// port-frame has already been absorbed) keeps its "ready" state when
+    /// later swapped to a real stream.
+    pub(crate) fn insert(&self, channel: u8, sender: mpsc::Sender<Bytes>, port_seen: bool) {
+        let mut slot = self.slots[channel as usize].write();
+        match slot.as_mut() {
+            Some(existing) => existing.sender = sender,
+            None => *slot = Some(ChannelEntry { sender, port_seen }),
+        }
+    }
+
+    pub(crate) fn remove(&self, channel: u8) {
+        *self.slots[channel as usize].write() = None;
+    }
+
+    /// Dispatch an inbound payload. On first frame for a not-yet-port-seen
+    /// channel, parses as the initial port-frame and flips the state without
+    /// forwarding (handshake absorption). Holds the slot's RwLock only across
+    /// the synchronous flip / sender-clone — never across the `.await`
+    /// (parking_lot::RwLock is not async-aware).
+    pub(crate) async fn dispatch(&self, channel: u8, payload: Bytes) {
+        let maybe_send = {
+            let mut slot = self.slots[channel as usize].write();
+            let Some(entry) = slot.as_mut() else {
+                tracing::debug!(channel, "dropping payload for unknown channel");
+                return;
+            };
+            if entry.port_seen {
+                Some(entry.sender.clone())
+            } else {
+                match frame::parse_initial_port_frame(&payload) {
+                    Ok(_) => {
+                        entry.port_seen = true;
+                    }
+                    Err(e) => {
+                        tracing::warn!(channel, error = %e, "failed to parse initial port frame");
+                    }
+                }
+                None
+            }
+        };
+        if let Some(sender) = maybe_send
+            && sender.send(payload).await.is_err()
+        {
+            tracing::trace!(channel, "channel receiver gone; discarding payload");
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn clear(&self) {
+        for slot in self.slots.iter() {
+            *slot.write() = None;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn router_dispatch_routes_to_correct_channel() {
+        let router = Router::new();
+        let (tx, mut rx) = mpsc::channel::<Bytes>(8);
+        router.insert(4, tx, true);
+
+        router.dispatch(4, Bytes::from_static(b"payload")).await;
+        let got = rx.recv().await.unwrap();
+        assert_eq!(&got[..], b"payload");
+    }
+
+    #[tokio::test]
+    async fn router_insert_preserves_port_seen_on_existing() {
+        let router = Router::new();
+        let (tx1, _rx1) = mpsc::channel::<Bytes>(1);
+        router.insert(2, tx1, true);
+
+        let (tx2, mut rx2) = mpsc::channel::<Bytes>(8);
+        router.insert(2, tx2, false);
+
+        router.dispatch(2, Bytes::from_static(b"data")).await;
+        let got = rx2.recv().await.unwrap();
+        assert_eq!(&got[..], b"data");
+    }
+
+    #[tokio::test]
+    async fn router_dispatch_drops_first_frame_as_port_frame_for_unseen() {
+        let router = Router::new();
+        let (tx, mut rx) = mpsc::channel::<Bytes>(8);
+        router.insert(0, tx, false);
+
+        router.dispatch(0, Bytes::from_static(&[0x50, 0x00])).await;
+        assert!(rx.try_recv().is_err());
+
+        router.dispatch(0, Bytes::from_static(b"real")).await;
+        let got = rx.recv().await.unwrap();
+        assert_eq!(&got[..], b"real");
+    }
+
+    #[tokio::test]
+    async fn router_unknown_channel_drops() {
+        let router = Router::new();
+        router.dispatch(99, Bytes::from_static(b"x")).await;
+    }
+}

--- a/crates/kube-portforward/src/session.rs
+++ b/crates/kube-portforward/src/session.rs
@@ -1,0 +1,199 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use parking_lot::Mutex;
+use tokio::sync::mpsc;
+use tokio::task::JoinSet;
+use tokio_tungstenite::tungstenite;
+use tokio_util::sync::CancellationToken;
+use tungstenite::Message;
+
+use crate::allocator::ChannelAllocator;
+use crate::error::Error;
+use crate::keepalive::{
+    KeepaliveHandle,
+    RecoveryCallback,
+};
+use crate::routing::Router;
+use crate::shutdown;
+use crate::stream::{
+    ChannelHalf,
+    ShutdownSignal,
+    Stream,
+};
+use crate::subprotocol::Subprotocol;
+
+#[derive(Clone, Copy)]
+struct AllocatedIds {
+    data: u8,
+    error: u8,
+}
+
+pub(crate) struct ReleaseGuard {
+    ids: Option<AllocatedIds>,
+    allocator: Arc<Mutex<ChannelAllocator>>,
+    router: Router,
+    shutdown_signal: Arc<ShutdownSignal>,
+    cancel: CancellationToken,
+}
+
+impl ReleaseGuard {
+    fn new(
+        ids: AllocatedIds, allocator: Arc<Mutex<ChannelAllocator>>, router: Router,
+        shutdown_signal: Arc<ShutdownSignal>, cancel: CancellationToken,
+    ) -> Self {
+        Self {
+            ids: Some(ids),
+            allocator,
+            router,
+            shutdown_signal,
+            cancel,
+        }
+    }
+}
+
+impl Drop for ReleaseGuard {
+    fn drop(&mut self) {
+        let Some(ids) = self.ids.take() else { return };
+        self.shutdown_signal.fire();
+        self.router.remove(ids.data);
+        self.router.remove(ids.error);
+        let drained = {
+            let mut alloc = self.allocator.lock();
+            alloc.release_pair(ids.data);
+            alloc.is_drained()
+        };
+        if drained {
+            self.cancel.cancel();
+        }
+    }
+}
+
+/// One WebSocket port-forward session that multiplexes up to `capacity_pairs`
+/// concurrent local connections (each backed by a data/error channel pair)
+/// over a single upgrade.
+pub struct Session {
+    allocator: Arc<Mutex<ChannelAllocator>>,
+    router: Router,
+    writer_mailbox: mpsc::Sender<Message>,
+    cancel: CancellationToken,
+    #[allow(dead_code)]
+    keepalive: KeepaliveHandle,
+    protocol: Subprotocol,
+    join_set: JoinSet<Result<(), Error>>,
+    drain_timeout: Duration,
+    #[allow(dead_code)]
+    recovery_callback: RecoveryCallback,
+}
+
+#[allow(clippy::too_many_arguments)]
+impl Session {
+    pub(crate) fn new(
+        allocator: Arc<Mutex<ChannelAllocator>>, router: Router,
+        writer_mailbox: mpsc::Sender<Message>, cancel: CancellationToken,
+        keepalive: KeepaliveHandle, protocol: Subprotocol, join_set: JoinSet<Result<(), Error>>,
+        drain_timeout: Duration, recovery_callback: RecoveryCallback,
+    ) -> Self {
+        Self {
+            allocator,
+            router,
+            writer_mailbox,
+            cancel,
+            keepalive,
+            protocol,
+            join_set,
+            drain_timeout,
+            recovery_callback,
+        }
+    }
+
+    /// Allocate the next channel pair and return a bidirectional [`Stream`].
+    pub async fn connect(&self) -> Result<Stream, Error> {
+        let (data_id, error_id) = {
+            let mut alloc = self.allocator.lock();
+            let live = alloc.live_count();
+            let capacity = alloc.capacity_pairs();
+            alloc.allocate_pair().ok_or(Error::CapacityExhausted {
+                in_use: live,
+                capacity,
+            })?
+        };
+
+        tracing::debug!(data_id, error_id, "opening channel pair");
+
+        let (data_half, data_inbound_tx) = ChannelHalf::pair(data_id, self.writer_mailbox.clone());
+        let (error_half, error_inbound_tx) =
+            ChannelHalf::pair(error_id, self.writer_mailbox.clone());
+
+        self.router.insert(data_id, data_inbound_tx, false);
+        self.router.insert(error_id, error_inbound_tx, false);
+
+        let shutdown_signal = ShutdownSignal::new(
+            data_id,
+            error_id,
+            self.writer_mailbox.clone(),
+            self.protocol.supports_half_close(),
+        );
+
+        let guard = ReleaseGuard::new(
+            AllocatedIds {
+                data: data_id,
+                error: error_id,
+            },
+            Arc::clone(&self.allocator),
+            self.router.clone(),
+            Arc::clone(&shutdown_signal),
+            self.cancel.clone(),
+        );
+
+        Ok(Stream::new(data_half, error_half, shutdown_signal, guard))
+    }
+
+    pub fn protocol(&self) -> Subprotocol {
+        self.protocol
+    }
+
+    /// Maximum number of concurrent streams this session can hold.
+    pub fn capacity(&self) -> usize {
+        self.allocator.lock().capacity_pairs()
+    }
+
+    /// Number of channel pairs currently in use.
+    pub fn in_use(&self) -> usize {
+        self.allocator.lock().live_count()
+    }
+
+    /// Pairs still available for new streams.
+    pub fn available(&self) -> usize {
+        let alloc = self.allocator.lock();
+        alloc.capacity_pairs() - alloc.live_count()
+    }
+
+    pub fn is_full(&self) -> bool {
+        self.allocator.lock().is_full()
+    }
+
+    /// Returns true if every channel pair this session preallocated has been
+    /// allocated AND released. A drained session can never produce another
+    /// stream — callers should drop it and open a new session.
+    pub fn is_drained(&self) -> bool {
+        self.allocator.lock().is_drained()
+    }
+
+    pub fn cancellation_token(&self) -> CancellationToken {
+        self.cancel.clone()
+    }
+
+    /// Gracefully close the session, draining background tasks within the
+    /// configured drain timeout before aborting any leftover work.
+    pub async fn close(mut self) -> Result<(), Error> {
+        shutdown::shutdown(
+            self.writer_mailbox.clone(),
+            self.cancel.clone(),
+            &mut self.join_set,
+            self.drain_timeout,
+        )
+        .await;
+        Ok(())
+    }
+}

--- a/crates/kube-portforward/src/shutdown.rs
+++ b/crates/kube-portforward/src/shutdown.rs
@@ -1,0 +1,52 @@
+use std::time::Duration;
+
+use tokio::sync::mpsc;
+use tokio::task::JoinSet;
+use tokio_util::sync::CancellationToken;
+use tungstenite::Message;
+
+use crate::error::Error;
+
+pub(crate) async fn shutdown(
+    writer_mailbox: mpsc::Sender<Message>, cancel: CancellationToken,
+    join_set: &mut JoinSet<Result<(), Error>>, drain_timeout: Duration,
+) {
+    let _ = tokio::time::timeout(
+        Duration::from_millis(100),
+        writer_mailbox.send(Message::Close(None)),
+    )
+    .await;
+
+    cancel.cancel();
+
+    let drain = async {
+        while let Some(result) = join_set.join_next().await {
+            match result {
+                Ok(Err(e)) => tracing::error!("background task returned error during drain: {e}"),
+                Err(e) if e.is_panic() => {
+                    tracing::error!("background task panicked during drain: {e}")
+                }
+                Err(e) if !e.is_cancelled() => {
+                    tracing::error!("background task join error during drain: {e}")
+                }
+                _ => {}
+            }
+        }
+    };
+
+    if tokio::time::timeout(drain_timeout, drain).await.is_err() {
+        let pending = join_set.len();
+        join_set.abort_all();
+        while let Some(result) = join_set.join_next().await {
+            match result {
+                Ok(Err(e)) => tracing::error!("aborted task returned error: {e}"),
+                Err(e) if e.is_panic() => tracing::error!("aborted task panicked: {e}"),
+                _ => {}
+            }
+        }
+        tracing::warn!(
+            "kube-portforward graceful shutdown timed out; aborted {} pending tasks",
+            pending
+        );
+    }
+}

--- a/crates/kube-portforward/src/stream.rs
+++ b/crates/kube-portforward/src/stream.rs
@@ -1,0 +1,467 @@
+use std::{
+    io,
+    pin::Pin,
+    sync::{
+        Arc,
+        atomic::{
+            AtomicBool,
+            Ordering,
+        },
+    },
+    task::{
+        Context,
+        Poll,
+    },
+};
+
+use bytes::{
+    Buf,
+    Bytes,
+};
+use tokio::{
+    io::{
+        AsyncBufRead,
+        AsyncRead,
+        AsyncWrite,
+        ReadBuf,
+    },
+    sync::mpsc,
+};
+use tokio_tungstenite::tungstenite;
+use tokio_util::sync::PollSender;
+
+use crate::frame;
+use crate::session::ReleaseGuard;
+
+pub(crate) struct ChannelHalf {
+    rx: mpsc::Receiver<Bytes>,
+    writer_mailbox: Option<PollSender<tungstenite::Message>>,
+    channel_id: u8,
+    read_buf: Option<Bytes>,
+    read_eof: bool,
+}
+
+impl ChannelHalf {
+    pub(crate) fn pair(
+        channel_id: u8, writer_mailbox: mpsc::Sender<tungstenite::Message>,
+    ) -> (Self, mpsc::Sender<Bytes>) {
+        let (inbound_tx, inbound_rx) = mpsc::channel(64);
+        let half = Self {
+            rx: inbound_rx,
+            writer_mailbox: Some(PollSender::new(writer_mailbox)),
+            channel_id,
+            read_buf: None,
+            read_eof: false,
+        };
+        (half, inbound_tx)
+    }
+}
+
+impl AsyncRead for ChannelHalf {
+    fn poll_read(
+        mut self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        // Drain buffered data first
+        if let Some(mut bytes) = self.read_buf.take() {
+            let n = bytes.len().min(buf.remaining());
+            let dst = buf.initialize_unfilled_to(n);
+            bytes.copy_to_slice(dst);
+            buf.advance(n);
+            if !bytes.is_empty() {
+                self.read_buf = Some(bytes);
+            }
+            return Poll::Ready(Ok(()));
+        }
+
+        if self.read_eof {
+            return Poll::Ready(Ok(()));
+        }
+
+        // No buffered data — poll the channel
+        match self.rx.poll_recv(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(None) => {
+                self.read_eof = true;
+                Poll::Ready(Ok(()))
+            }
+            Poll::Ready(Some(bytes)) => {
+                self.read_buf = Some(bytes);
+                // Re-enter to copy from the newly buffered data
+                Pin::new(&mut *self).poll_read(cx, buf)
+            }
+        }
+    }
+}
+
+impl AsyncBufRead for ChannelHalf {
+    fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<&[u8]>> {
+        let this = self.get_mut();
+        loop {
+            if this.read_buf.as_ref().is_some_and(|b| !b.is_empty()) {
+                // as_deref() gives us &[u8] borrowed from this.read_buf, which
+                // satisfies the 'self lifetime requirement of poll_fill_buf.
+                // unwrap is safe: we just verified Some + non-empty above.
+                return Poll::Ready(Ok(this.read_buf.as_deref().unwrap()));
+            }
+            if this.read_buf.is_some() {
+                this.read_buf = None;
+            }
+            if this.read_eof {
+                return Poll::Ready(Ok(&[]));
+            }
+            match this.rx.poll_recv(cx) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(None) => {
+                    this.read_eof = true;
+                    return Poll::Ready(Ok(&[]));
+                }
+                Poll::Ready(Some(b)) => {
+                    this.read_buf = Some(b);
+                }
+            }
+        }
+    }
+
+    fn consume(self: Pin<&mut Self>, amt: usize) {
+        let this = self.get_mut();
+        if let Some(ref mut bytes) = this.read_buf {
+            let consumed = amt.min(bytes.len());
+            bytes.advance(consumed);
+            if bytes.is_empty() {
+                this.read_buf = None;
+            }
+        }
+    }
+}
+
+impl AsyncWrite for ChannelHalf {
+    fn poll_write(
+        mut self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        let reserve = match self.writer_mailbox.as_mut() {
+            None => {
+                return Poll::Ready(Err(io::Error::new(
+                    io::ErrorKind::BrokenPipe,
+                    "channel closed",
+                )));
+            }
+            Some(tx) => Pin::new(tx).poll_reserve(cx),
+        };
+        match reserve {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Err(_)) => {
+                self.writer_mailbox = None;
+                Poll::Ready(Err(io::Error::new(
+                    io::ErrorKind::BrokenPipe,
+                    "channel closed",
+                )))
+            }
+            Poll::Ready(Ok(())) => {
+                let channel_id = self.channel_id;
+                let item = frame::bytes_to_message(frame::encode_channel_frame(channel_id, buf));
+                let send_outcome = match self.writer_mailbox.as_mut() {
+                    None => Err(()),
+                    Some(tx) => tx.send_item(item).map_err(|_| ()),
+                };
+                match send_outcome {
+                    Ok(()) => Poll::Ready(Ok(buf.len())),
+                    Err(()) => {
+                        self.writer_mailbox = None;
+                        Poll::Ready(Err(io::Error::new(
+                            io::ErrorKind::BrokenPipe,
+                            "channel closed",
+                        )))
+                    }
+                }
+            }
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.writer_mailbox = None;
+        Poll::Ready(Ok(()))
+    }
+}
+
+/// Idempotent half-close signaller for a single channel pair.
+///
+/// On v5 sessions, `fire()` emits `[0xFF, data_channel_id]` and
+/// `[0xFF, error_channel_id]` to the writer mailbox, telling the apiserver
+/// the client is done writing on this pair. The server tears down its
+/// backend pod connection and echoes `0xFF` back; our reader sees that and
+/// removes the routing entry, which surfaces as EOF to the user's read
+/// half — this is the chain that resolves CLOSE_WAIT on the kftray-side
+/// listener.
+///
+/// On v4 sessions (`supports_close == false`), `fire()` is a no-op at the
+/// protocol layer: v4 has no half-close frame, so CLOSE_WAIT on v4 cannot
+/// be fixed from the client. v4 is the rare fallback for pre-1.30 clusters
+/// (see KEP-4006).
+pub(crate) struct ShutdownSignal {
+    data_channel: u8,
+    error_channel: u8,
+    writer_mailbox: mpsc::Sender<tungstenite::Message>,
+    supports_close: bool,
+    sent: AtomicBool,
+}
+
+impl ShutdownSignal {
+    pub(crate) fn new(
+        data_channel: u8, error_channel: u8, writer_mailbox: mpsc::Sender<tungstenite::Message>,
+        supports_close: bool,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            data_channel,
+            error_channel,
+            writer_mailbox,
+            supports_close,
+            sent: AtomicBool::new(false),
+        })
+    }
+
+    /// Idempotent. Sends 0xFF close signal for both channels on v5;
+    /// no-op on v4. Uses `try_send` first to stay non-blocking; falls
+    /// back to a spawned async send only if the mailbox is full.
+    pub(crate) fn fire(&self) {
+        if !self.supports_close {
+            return;
+        }
+        if self.sent.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        let close_data = frame::bytes_to_message(frame::encode_close_signal(self.data_channel));
+        let close_error = frame::bytes_to_message(frame::encode_close_signal(self.error_channel));
+        for msg in [close_data, close_error] {
+            if let Err(err) = self.writer_mailbox.try_send(msg) {
+                match err {
+                    mpsc::error::TrySendError::Full(msg) => {
+                        // fire() can be called from ReleaseGuard::drop (sync context).
+                        // tokio::spawn panics if no runtime is active, so guard with
+                        // Handle::try_current().
+                        match tokio::runtime::Handle::try_current() {
+                            Ok(handle) => {
+                                let mailbox = self.writer_mailbox.clone();
+                                handle.spawn(async move {
+                                    let _ = mailbox.send(msg).await;
+                                });
+                            }
+                            Err(_) => {
+                                // No runtime — best-effort drop; channel was
+                                // full.
+                            }
+                        }
+                    }
+                    mpsc::error::TrySendError::Closed(_) => {
+                        // Writer task is gone — session is tearing down,
+                        // nothing to send.
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Bidirectional port-forward stream backed by one (data, error) channel pair
+/// in a multiplexed WebSocket session. Implements `AsyncRead` + `AsyncWrite`
+/// on the data half. Dropping the `Stream` (or calling `poll_shutdown`)
+/// emits a v5 close signal so the apiserver tears down the backing pod
+/// connection promptly.
+pub struct Stream {
+    data: ChannelHalf,
+    error: ChannelHalf,
+    shutdown_signal: Arc<ShutdownSignal>,
+    _guard: ReleaseGuard,
+}
+
+impl Stream {
+    pub(crate) fn new(
+        data: ChannelHalf, error: ChannelHalf, shutdown_signal: Arc<ShutdownSignal>,
+        guard: ReleaseGuard,
+    ) -> Self {
+        Self {
+            data,
+            error,
+            shutdown_signal,
+            _guard: guard,
+        }
+    }
+
+    /// Split the stream into its data half (`AsyncRead + AsyncWrite`) and
+    /// error half (`AsyncRead`-only). Both halves share the same release
+    /// guard; dropping both releases the channel pair. Only the data half
+    /// can emit the v5 shutdown signal.
+    pub fn split(self) -> (DataStream, ErrorStream) {
+        let guard = Arc::new(self._guard);
+        (
+            DataStream {
+                inner: self.data,
+                shutdown_signal: self.shutdown_signal,
+                _guard: Arc::clone(&guard),
+            },
+            ErrorStream {
+                inner: self.error,
+                _guard: guard,
+            },
+        )
+    }
+}
+
+impl AsyncRead for Stream {
+    fn poll_read(
+        mut self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.data).poll_read(cx, buf)
+    }
+}
+
+impl AsyncBufRead for Stream {
+    fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<&[u8]>> {
+        let this = self.get_mut();
+        Pin::new(&mut this.data).poll_fill_buf(cx)
+    }
+
+    fn consume(self: Pin<&mut Self>, amt: usize) {
+        let this = self.get_mut();
+        Pin::new(&mut this.data).consume(amt)
+    }
+}
+
+impl AsyncWrite for Stream {
+    fn poll_write(
+        mut self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.data).poll_write(cx, buf)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.data).poll_flush(cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.shutdown_signal.fire();
+        Pin::new(&mut self.data).poll_shutdown(cx)
+    }
+}
+
+pub struct DataStream {
+    inner: ChannelHalf,
+    shutdown_signal: Arc<ShutdownSignal>,
+    _guard: Arc<ReleaseGuard>,
+}
+
+impl AsyncRead for DataStream {
+    fn poll_read(
+        mut self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_read(cx, buf)
+    }
+}
+
+impl AsyncBufRead for DataStream {
+    fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<&[u8]>> {
+        let this = self.get_mut();
+        Pin::new(&mut this.inner).poll_fill_buf(cx)
+    }
+
+    fn consume(self: Pin<&mut Self>, amt: usize) {
+        let this = self.get_mut();
+        Pin::new(&mut this.inner).consume(amt)
+    }
+}
+
+impl AsyncWrite for DataStream {
+    fn poll_write(
+        mut self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.inner).poll_write(cx, buf)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.shutdown_signal.fire();
+        Pin::new(&mut self.inner).poll_shutdown(cx)
+    }
+}
+
+pub struct ErrorStream {
+    inner: ChannelHalf,
+    _guard: Arc<ReleaseGuard>,
+}
+
+impl AsyncRead for ErrorStream {
+    fn poll_read(
+        mut self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_read(cx, buf)
+    }
+}
+
+const _ASSERT_TRAITS: fn() = || {
+    fn assert<T: AsyncRead + AsyncWrite + Unpin + Send + 'static>() {}
+    assert::<Stream>();
+    assert::<DataStream>();
+};
+
+#[cfg(test)]
+mod tests {
+    use tokio::io::{
+        AsyncReadExt,
+        AsyncWriteExt,
+    };
+
+    use super::*;
+
+    #[tokio::test]
+    async fn channel_half_round_trip() {
+        let (writer_tx, mut writer_rx) = mpsc::channel::<tungstenite::Message>(8);
+        let (mut half, inbound_tx) = ChannelHalf::pair(7, writer_tx);
+
+        inbound_tx.send(Bytes::from_static(b"hello")).await.unwrap();
+        let mut buf = vec![0u8; 5];
+        half.read_exact(&mut buf).await.unwrap();
+        assert_eq!(&buf, b"hello");
+
+        half.write_all(b"world").await.unwrap();
+        let got = writer_rx.recv().await.unwrap();
+        let expected = frame::bytes_to_message(frame::encode_channel_frame(7, b"world"));
+        assert_eq!(got, expected);
+    }
+
+    #[tokio::test]
+    async fn shutdown_signal_v5_emits_close_frames_once() {
+        let (writer_tx, mut writer_rx) = mpsc::channel::<tungstenite::Message>(8);
+        let sig = ShutdownSignal::new(4, 5, writer_tx, true);
+
+        sig.fire();
+        sig.fire();
+
+        let msg1 = writer_rx.recv().await.unwrap();
+        let msg2 = writer_rx.recv().await.unwrap();
+        assert!(
+            writer_rx.try_recv().is_err(),
+            "fire() must be idempotent and only emit one pair of close frames"
+        );
+
+        let data_close = frame::bytes_to_message(frame::encode_close_signal(4));
+        let error_close = frame::bytes_to_message(frame::encode_close_signal(5));
+        assert_eq!(msg1, data_close);
+        assert_eq!(msg2, error_close);
+    }
+
+    #[tokio::test]
+    async fn shutdown_signal_v4_is_noop() {
+        let (writer_tx, mut writer_rx) = mpsc::channel::<tungstenite::Message>(8);
+        let sig = ShutdownSignal::new(0, 1, writer_tx, false);
+
+        sig.fire();
+
+        assert!(writer_rx.try_recv().is_err());
+    }
+}

--- a/crates/kube-portforward/src/subprotocol.rs
+++ b/crates/kube-portforward/src/subprotocol.rs
@@ -1,0 +1,32 @@
+/// WebSocket subprotocol negotiated for a port-forward session.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum Subprotocol {
+    /// `v5.channel.k8s.io` — supports the `[0xFF, channel]` half-close signal,
+    /// letting the client release channel IDs back to the allocator's free-list
+    /// within a session.
+    V5,
+    /// `v4.channel.k8s.io` — original framing, no half-close. Released IDs
+    /// stay reserved until the session ends.
+    V4,
+}
+
+impl std::fmt::Display for Subprotocol {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::V5 => f.write_str("v5"),
+            Self::V4 => f.write_str("v4"),
+        }
+    }
+}
+
+impl Subprotocol {
+    /// Whether this subprotocol supports half-close (channel ID reuse).
+    pub fn supports_half_close(&self) -> bool {
+        matches!(self, Self::V5)
+    }
+
+    pub(crate) fn offered_header_value() -> &'static str {
+        "v5.channel.k8s.io, v4.channel.k8s.io"
+    }
+}

--- a/crates/kube-portforward/src/version.rs
+++ b/crates/kube-portforward/src/version.rs
@@ -1,0 +1,115 @@
+use crate::error::Error;
+
+/// Apiserver version metadata used to gate on KEP-4006 (WebSocket port-forward
+/// requires >= 1.30).
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub struct VersionInfo {
+    pub major: u32,
+    pub minor: u32,
+    pub git_version: String,
+}
+
+impl VersionInfo {
+    /// Create a new `VersionInfo`.
+    pub fn new(major: u32, minor: u32, git_version: String) -> Self {
+        Self {
+            major,
+            minor,
+            git_version,
+        }
+    }
+
+    pub fn supports_ws_portforward(&self) -> bool {
+        (self.major, self.minor) >= (1, 30)
+    }
+}
+
+fn parse_component(version_part: &str) -> Result<u32, Error> {
+    let digits: String = version_part
+        .chars()
+        .take_while(|c| c.is_ascii_digit())
+        .collect();
+    digits.parse().map_err(|e: std::num::ParseIntError| {
+        Error::Configuration(format!(
+            "could not parse apiserver version component '{version_part}': {e}"
+        ))
+    })
+}
+
+/// Query the apiserver's `/version` endpoint.
+pub async fn detect(client: &kube::Client) -> Result<VersionInfo, Error> {
+    let info = client.apiserver_version().await.map_err(Error::Kube)?;
+
+    Ok(VersionInfo {
+        major: parse_component(&info.major)?,
+        minor: parse_component(&info.minor)?,
+        git_version: info.git_version,
+    })
+}
+
+#[cfg(feature = "version-cache")]
+mod cache {
+    use std::sync::OnceLock;
+    use std::time::{
+        Duration,
+        Instant,
+    };
+
+    use dashmap::DashMap;
+
+    use super::VersionInfo;
+
+    const VERSION_TTL: Duration = Duration::from_secs(3600);
+
+    /// Process-wide version cache keyed by cluster URL. Opt-in via the
+    /// `version-cache` feature.
+    pub struct VersionCache {
+        map: DashMap<String, (VersionInfo, Instant)>,
+    }
+
+    impl Default for VersionCache {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    impl VersionCache {
+        pub fn new() -> Self {
+            Self {
+                map: DashMap::new(),
+            }
+        }
+
+        pub fn get(&self, cluster_url: &str) -> Option<VersionInfo> {
+            self.map.get(cluster_url).and_then(|entry| {
+                let (info, cached_at) = entry.value();
+                if cached_at.elapsed() < VERSION_TTL {
+                    Some(info.clone())
+                } else {
+                    None
+                }
+            })
+        }
+
+        pub fn insert(&self, cluster_url: String, info: VersionInfo) {
+            self.map.insert(cluster_url, (info, Instant::now()));
+        }
+
+        pub fn invalidate(&self, cluster_url: &str) {
+            self.map.remove(cluster_url);
+        }
+    }
+
+    static GLOBAL_VERSION_CACHE_CELL: OnceLock<VersionCache> = OnceLock::new();
+
+    pub fn global_version_cache() -> &'static VersionCache {
+        GLOBAL_VERSION_CACHE_CELL.get_or_init(VersionCache::new)
+    }
+}
+
+#[cfg(feature = "version-cache")]
+pub use cache::{
+    VersionCache,
+    global_version_cache,
+};

--- a/crates/kube-portforward/src/writer.rs
+++ b/crates/kube-portforward/src/writer.rs
@@ -1,0 +1,44 @@
+use futures::SinkExt;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+use tungstenite::Message;
+
+use crate::error::Error;
+
+const BATCH_CAP: usize = 32;
+
+pub(crate) async fn writer_task<S>(
+    mut sink: S, mut rx: mpsc::Receiver<Message>, cancel: CancellationToken,
+) -> Result<(), Error>
+where
+    S: SinkExt<Message, Error = tungstenite::Error> + Unpin + Send,
+{
+    let mut batch: Vec<Message> = Vec::with_capacity(BATCH_CAP);
+    loop {
+        tokio::select! {
+            biased;
+            _ = cancel.cancelled() => {
+                let _ = sink.close().await;
+                return Ok(());
+            }
+            n = rx.recv_many(&mut batch, BATCH_CAP) => {
+                if n == 0 {
+                    let _ = sink.close().await;
+                    return Ok(());
+                }
+                for msg in batch.drain(..) {
+                    if let Err(e) = sink.feed(msg).await {
+                        tracing::warn!(error = %e, "WebSocket sink feed error, closing writer");
+                        let _ = sink.close().await;
+                        return Ok(());
+                    }
+                }
+                if let Err(e) = sink.flush().await {
+                    tracing::warn!(error = %e, "WebSocket sink flush error, closing writer");
+                    let _ = sink.close().await;
+                    return Ok(());
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Stack Context

This stack restructures the `websocket-pf` branch into 11 atomic PRs.
The goal is to extract a standalone `kube-portforward` crate (OSS-ready
WebSocket port-forwarder for Kubernetes) and rebuild kftray's port-forward
path on top of it, with a new HTTP proxy in kftray-server.

Stack order (bottom to top):
1. ws-pf/dev-tooling — dev tooling and gitignore
2. ws-pf/workspace-deps — workspace dependency consolidation
3. ws-pf/kube-portforward-crate — new kube-portforward crate
4. ws-pf/portforward-deps — wire kftray-portforward to new crate
5. ws-pf/ssl-platform-cleanup — remove dead SSL platform code
6. ws-pf/server-http-proxy — HTTP proxy with relay and sniffer
7. ws-pf/kube-registry-refactor — registry + kube listener rebuilt
8. ws-pf/expose-updates — expose flows through new registry
9. ws-pf/network-monitor-fix — PortForwardError type fix
10. ws-pf/tauri-integration — tauri command wiring
11. ws-pf/kftui-integration — kftui integration (top)

## Why?

Extracts the WebSocket port-forward implementation into an independent, publishable crate. `kube-portforward` speaks both v4 and v5 channel-mux subprotocols (KEP-4006), multiplexes N local TCP connections over a single WebSocket upgrade, includes keepalive, graceful shutdown, session recovery, and pod watching. Decoupled from kftray's internal state so it can be used as a library by other projects.

## What?

- `crates/kube-portforward/` (new: Cargo.toml, MIT+Apache licenses, README, 4 examples, 18 src files)
