### PR TITLE
chore(portforward): depend on kube-portforward workspace crate

### DIFF
--- a/crates/kftray-portforward/Cargo.toml
+++ b/crates/kftray-portforward/Cargo.toml
@@ -42,13 +42,14 @@ httparse = { workspace = true }
 hyper = { workspace = true }
 hyper-openssl = { workspace = true }
 hyper-util = { workspace = true }
-jiff = { version = "0.2", features = ["serde"] }
+jiff = { workspace = true }
 k8s-openapi = { workspace = true }
 keyring-core = { workspace = true }
 kftray-commons = { workspace = true }
 kftray-helper = { workspace = true }
 kftray-http-logs = { workspace = true }
 kube = { workspace = true }
+kube-portforward = { workspace = true }
 kube-runtime = { workspace = true }
 lazy_static = { workspace = true }
 libc = { workspace = true }
@@ -89,12 +90,12 @@ dbus-secret-service-keyring-store = { workspace = true }
 linux-keyutils-keyring-store = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-security-framework = "3.7.0"
-core-foundation = "0.10.1"
+security-framework = { workspace = true }
+core-foundation = { workspace = true }
 apple-native-keyring-store = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-schannel = "0.1.29"
+schannel = { workspace = true }
 windows = { workspace = true }
 windows-native-keyring-store = { workspace = true }
 


### PR DESCRIPTION
## Stack Context

This stack restructures the `websocket-pf` branch into 11 atomic PRs.
The goal is to extract a standalone `kube-portforward` crate (OSS-ready
WebSocket port-forwarder for Kubernetes) and rebuild kftray's port-forward
path on top of it, with a new HTTP proxy in kftray-server.

Stack order (bottom to top):
1. ws-pf/dev-tooling — dev tooling and gitignore
2. ws-pf/workspace-deps — workspace dependency consolidation
3. ws-pf/kube-portforward-crate — new kube-portforward crate
4. ws-pf/portforward-deps — wire kftray-portforward to new crate
5. ws-pf/ssl-platform-cleanup — remove dead SSL platform code
6. ws-pf/server-http-proxy — HTTP proxy with relay and sniffer
7. ws-pf/kube-registry-refactor — registry + kube listener rebuilt
8. ws-pf/expose-updates — expose flows through new registry
9. ws-pf/network-monitor-fix — PortForwardError type fix
10. ws-pf/tauri-integration — tauri command wiring
11. ws-pf/kftui-integration — kftui integration (top)

## Why?

Adds `kube-portforward = { workspace = true }` to `kftray-portforward`'s dependencies, making the new crate available to the listener refactor that follows. Also workspace-ifies several inline version pins for consistency.

## What?

- `crates/kftray-portforward/Cargo.toml`
