### PR TITLE
feat(server): add HTTP proxy with relay and sniffer

### DIFF
--- a/crates/kftray-server/Cargo.toml
+++ b/crates/kftray-server/Cargo.toml
@@ -9,23 +9,25 @@ repository = "https://github.com/hcavarsan/kftray"
 license = "GPL-3.0"
 
 [dependencies]
-async-trait = "0.1.89"
-bytes = "1.11"
-env_logger = "0.11.10"
+async-trait = "0.1"
+bytes = "1"
 futures = "0.3"
-http = "1.4"
+http = "1"
 http-body-util = "0.1"
-hyper = { version = "1.9.0", features = ["full"] }
+hyper = { version = "1", features = ["full"] }
 hyper-util = { version = "0.1", features = ["full"] }
-log = "0.4.29"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-socket2 = "0.6.3"
-tokio = { version = "1.52.3", features = ["full", "macros", "rt-multi-thread"] }
-tokio-tungstenite = { version = "0.29.0", features = ["rustls-tls-webpki-roots"] }
-tungstenite = "0.29.0"
-url = "2.5.8"
-uuid = { version = "1.23", features = ["v4"] }
+log = "0.4"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+socket2 = "0.6"
+tokio = { version = "1", features = ["full"] }
+tokio-tungstenite = { version = "0.29", features = ["rustls-tls-webpki-roots"] }
+tokio-util = { version = "0.7", features = ["rt"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "tracing-log"] }
+tungstenite = "0.29"
+url = "2"
+uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
-lazy_static = "1.5.0"
+lazy_static = "1"

--- a/crates/kftray-server/src/main.rs
+++ b/crates/kftray-server/src/main.rs
@@ -129,7 +129,14 @@ fn load_config() -> Result<ProxyConfig, ProxyError> {
 /// and handles shutdown signals (Ctrl+C and SIGTERM)
 #[tokio::main]
 async fn main() -> Result<(), ProxyError> {
-    env_logger::init();
+    let filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
+
+    tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_target(true)
+        .with_ansi(false)
+        .init();
 
     let config = load_config()?;
     let server = Arc::new(ProxyServer::new(config));

--- a/crates/kftray-server/src/proxy/http_proxy.rs
+++ b/crates/kftray-server/src/proxy/http_proxy.rs
@@ -1,0 +1,289 @@
+//! HTTP/1.1 and HTTP/2 reverse proxy with per-request pooled upstream client.
+//!
+//! Inbound connections are served by hyper; outbound requests check out a
+//! pooled connection from `hyper_util::client::legacy::Client`, decoupling
+//! inbound TCP lifetime from outbound TCP lifetime. This is the fix for the
+//! multiplexed-channel-vs-HTTP-keep-alive regression: each forwarded request
+//! gets a fresh checkout from the pool, so upstream-idle closes are invisible.
+
+use std::convert::Infallible;
+use std::sync::Arc;
+use std::time::Duration;
+
+use http_body_util::{
+    BodyExt,
+    Full,
+    combinators::BoxBody,
+};
+use hyper::body::{
+    Bytes,
+    Incoming,
+};
+use hyper::header::{
+    HOST,
+    HeaderValue,
+};
+use hyper::server::conn::{
+    http1 as server_http1,
+    http2 as server_http2,
+};
+use hyper::service::service_fn;
+use hyper::{
+    Request,
+    Response,
+    Uri,
+};
+use hyper_util::client::legacy::Client;
+use hyper_util::client::legacy::connect::HttpConnector;
+use hyper_util::rt::{
+    TokioExecutor,
+    TokioIo,
+    TokioTimer,
+};
+use tokio::net::TcpStream;
+use tokio_util::sync::CancellationToken;
+
+use crate::proxy::config::ProxyConfig;
+use crate::proxy::error::ProxyError;
+
+static HOP_HEADERS: &[&str] = &[
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailers",
+    "transfer-encoding",
+    "upgrade",
+];
+
+type ResponseBody = BoxBody<Bytes, hyper::Error>;
+
+/// Cheap-to-clone HTTP reverse proxy with a shared, pooled upstream client.
+#[derive(Clone)]
+pub struct HttpProxy {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
+    client: Client<HttpConnector, Incoming>,
+    target_authority: String,
+}
+
+impl HttpProxy {
+    /// Build a new proxy for the given target. Initialises the pooled client.
+    pub fn new(config: &ProxyConfig) -> Self {
+        let mut connector = HttpConnector::new();
+        connector.set_nodelay(true);
+        connector.set_connect_timeout(Some(Duration::from_secs(5)));
+        connector.set_keepalive(Some(Duration::from_secs(60)));
+        connector.enforce_http(true);
+
+        let client = Client::builder(TokioExecutor::new())
+            .pool_idle_timeout(Duration::from_secs(30))
+            .pool_max_idle_per_host(16)
+            .pool_timer(TokioTimer::new())
+            .build(connector);
+
+        let host = config
+            .resolved_ip
+            .clone()
+            .unwrap_or_else(|| config.target_host.clone());
+        let target_authority = format!("{}:{}", host, config.target_port);
+
+        Self {
+            inner: Arc::new(Inner {
+                client,
+                target_authority,
+            }),
+        }
+    }
+
+    /// Serve a single inbound HTTP/1.x connection until close or cancellation.
+    pub async fn serve_http1(
+        self, inbound: TcpStream, cancel: CancellationToken,
+    ) -> Result<(), ProxyError> {
+        let peer_addr = inbound
+            .peer_addr()
+            .map(|a| a.to_string())
+            .unwrap_or_else(|_| "unknown".into());
+        let span = tracing::info_span!("http_serve", version = "http1", peer = %peer_addr);
+        let _guard = span.enter();
+
+        let _ = inbound.set_nodelay(true);
+        let io = TokioIo::new(inbound);
+        let proxy = self.clone();
+        let service = service_fn(move |req: Request<Incoming>| {
+            let proxy = proxy.clone();
+            async move { Ok::<_, Infallible>(proxy.forward(req).await) }
+        });
+
+        let conn = server_http1::Builder::new()
+            .keep_alive(true)
+            .timer(TokioTimer::new())
+            .serve_connection(io, service)
+            .with_upgrades();
+
+        tokio::select! {
+            res = conn => res.map_err(|e| ProxyError::Connection(format!("http1 serve: {e}"))),
+            _ = cancel.cancelled() => Ok(()),
+        }
+    }
+
+    /// Serve a single inbound HTTP/2 (cleartext h2c) connection.
+    pub async fn serve_http2(
+        self, inbound: TcpStream, cancel: CancellationToken,
+    ) -> Result<(), ProxyError> {
+        let peer_addr = inbound
+            .peer_addr()
+            .map(|a| a.to_string())
+            .unwrap_or_else(|_| "unknown".into());
+        let span = tracing::info_span!("http_serve", version = "http2", peer = %peer_addr);
+        let _guard = span.enter();
+
+        let _ = inbound.set_nodelay(true);
+        let io = TokioIo::new(inbound);
+        let proxy = self.clone();
+        let service = service_fn(move |req: Request<Incoming>| {
+            let proxy = proxy.clone();
+            async move { Ok::<_, Infallible>(proxy.forward(req).await) }
+        });
+
+        let conn = server_http2::Builder::new(TokioExecutor::new())
+            .timer(TokioTimer::new())
+            .serve_connection(io, service);
+
+        tokio::select! {
+            res = conn => res.map_err(|e| ProxyError::Connection(format!("http2 serve: {e}"))),
+            _ = cancel.cancelled() => Ok(()),
+        }
+    }
+
+    async fn forward(&self, req: Request<Incoming>) -> Response<ResponseBody> {
+        match self.try_forward(req).await {
+            Ok(resp) => resp,
+            Err(e) => {
+                log::warn!("http proxy forward error: {e}");
+                error_response(502, "Bad Gateway")
+            }
+        }
+    }
+
+    async fn try_forward(
+        &self, mut req: Request<Incoming>,
+    ) -> Result<Response<ResponseBody>, ProxyError> {
+        tracing::debug!(method = %req.method(), uri = %req.uri(), "forward: start");
+
+        let is_upgrade = req
+            .headers()
+            .get("connection")
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_ascii_lowercase().contains("upgrade"))
+            .unwrap_or(false);
+
+        if is_upgrade {
+            tracing::warn!(uri = %req.uri(), "forward: HTTP Upgrade not implemented; returning 501");
+            return Ok(error_response(501, "Upgrade Not Implemented"));
+        }
+
+        rewrite_request(&mut req, &self.inner.target_authority)?;
+
+        tracing::debug!(target = %self.inner.target_authority, "forward: dispatching to upstream");
+
+        let upstream = self.inner.client.request(req).await.map_err(|e| {
+            tracing::warn!(error = %e, "forward: upstream error");
+            ProxyError::Connection(format!("upstream: {e}"))
+        })?;
+
+        tracing::debug!(status = %upstream.status(), "forward: upstream responded");
+
+        let (mut parts, body) = upstream.into_parts();
+        for h in HOP_HEADERS {
+            parts.headers.remove(*h);
+        }
+        Ok(Response::from_parts(parts, body.boxed()))
+    }
+}
+
+fn rewrite_request(req: &mut Request<Incoming>, authority: &str) -> Result<(), ProxyError> {
+    let path_and_query = req
+        .uri()
+        .path_and_query()
+        .map(|p| p.as_str())
+        .unwrap_or("/")
+        .to_string();
+    let new_uri: Uri = format!("http://{authority}{path_and_query}")
+        .parse()
+        .map_err(|e| ProxyError::Connection(format!("uri build: {e}")))?;
+
+    for h in HOP_HEADERS {
+        req.headers_mut().remove(*h);
+    }
+    req.headers_mut().remove(HOST);
+    req.headers_mut().insert(
+        HOST,
+        HeaderValue::from_str(authority)
+            .map_err(|e| ProxyError::Connection(format!("host header: {e}")))?,
+    );
+    *req.uri_mut() = new_uri;
+    Ok(())
+}
+
+fn error_response(status: u16, msg: &'static str) -> Response<ResponseBody> {
+    let body = Full::new(Bytes::from_static(msg.as_bytes()))
+        .map_err(|never: Infallible| match never {})
+        .boxed();
+    Response::builder()
+        .status(status)
+        .header("content-type", "text/plain")
+        .body(body)
+        .expect("static response is well-formed")
+}
+
+#[cfg(test)]
+mod tests {
+    use hyper::HeaderMap;
+
+    use super::*;
+
+    fn strip(headers: &mut HeaderMap) {
+        for h in HOP_HEADERS {
+            headers.remove(*h);
+        }
+    }
+
+    #[test]
+    fn forward_strips_hop_by_hop_headers() {
+        let mut headers = HeaderMap::new();
+        headers.insert("connection", HeaderValue::from_static("keep-alive"));
+        headers.insert("transfer-encoding", HeaderValue::from_static("chunked"));
+        headers.insert("upgrade", HeaderValue::from_static("h2c"));
+        headers.insert("te", HeaderValue::from_static("trailers"));
+        headers.insert("x-keep", HeaderValue::from_static("yes"));
+
+        strip(&mut headers);
+
+        assert!(!headers.contains_key("connection"));
+        assert!(!headers.contains_key("transfer-encoding"));
+        assert!(!headers.contains_key("upgrade"));
+        assert!(!headers.contains_key("te"));
+        assert_eq!(headers.get("x-keep").unwrap(), "yes");
+    }
+
+    #[test]
+    fn forward_sets_host_to_target_authority() {
+        let authority = "target.local:9000";
+        let value = HeaderValue::from_str(authority).unwrap();
+        let mut headers = HeaderMap::new();
+        headers.insert(HOST, HeaderValue::from_static("old.example"));
+        headers.remove(HOST);
+        headers.insert(HOST, value);
+        assert_eq!(headers.get(HOST).unwrap(), authority);
+    }
+
+    #[test]
+    fn error_response_has_status() {
+        let r = error_response(502, "Bad Gateway");
+        assert_eq!(r.status(), 502);
+    }
+}

--- a/crates/kftray-server/src/proxy/mod.rs
+++ b/crates/kftray-server/src/proxy/mod.rs
@@ -1,8 +1,11 @@
 pub mod config;
 pub mod error;
+pub mod http_proxy;
+pub mod relay;
 pub mod reverse;
 pub mod reverse_http;
 pub mod server;
+pub mod sniff;
 pub mod tcp;
 pub mod traits;
 pub mod udp;

--- a/crates/kftray-server/src/proxy/relay.rs
+++ b/crates/kftray-server/src/proxy/relay.rs
@@ -1,0 +1,167 @@
+//! Bidirectional byte-pump for non-HTTP traffic with direct per-session
+//! outbound connections (no pool — raw TCP sessions are pinned 1:1).
+
+use std::time::Duration;
+
+use socket2::SockRef;
+use tokio::io::copy_bidirectional;
+use tokio::net::TcpStream;
+use tokio::time::timeout;
+use tokio_util::sync::CancellationToken;
+
+use crate::proxy::config::ProxyConfig;
+use crate::proxy::error::ProxyError;
+
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+const KEEPALIVE_IDLE: Duration = Duration::from_secs(60);
+const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(10);
+
+/// Connect directly to the proxy target (no pool).
+///
+/// Prefers `resolved_ip` when available, falls back to `target_host`.
+async fn connect_to_target(config: &ProxyConfig) -> Result<TcpStream, ProxyError> {
+    if let Some(ref ip) = config.resolved_ip {
+        let addr = format!("{}:{}", ip, config.target_port);
+        match try_connect(&addr).await {
+            Ok(s) => return Ok(s),
+            Err(e) => log::warn!("direct connect to resolved IP {addr} failed: {e}"),
+        }
+    }
+    let addr = format!("{}:{}", config.target_host, config.target_port);
+    try_connect(&addr)
+        .await
+        .map_err(|e| ProxyError::Connection(format!("connect to {addr} failed: {e}")))
+}
+
+async fn try_connect(addr: &str) -> Result<TcpStream, std::io::Error> {
+    let stream = timeout(CONNECT_TIMEOUT, TcpStream::connect(addr))
+        .await
+        .map_err(|_| std::io::Error::new(std::io::ErrorKind::TimedOut, "connect timeout"))??;
+    apply_keepalive(&stream)?;
+    let _ = stream.set_nodelay(true);
+    Ok(stream)
+}
+
+fn apply_keepalive(stream: &TcpStream) -> Result<(), std::io::Error> {
+    let sock = SockRef::from(stream);
+    let cfg = socket2::TcpKeepalive::new()
+        .with_time(KEEPALIVE_IDLE)
+        .with_interval(KEEPALIVE_INTERVAL);
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    let cfg = cfg.with_retries(3);
+    sock.set_tcp_keepalive(&cfg)
+}
+
+/// Relay bytes between an inbound stream and a directly-connected outbound
+/// stream until either side reaches EOF or the cancellation token fires.
+pub async fn relay_direct(
+    mut inbound: TcpStream, config: &ProxyConfig, cancel: CancellationToken,
+) -> Result<(), ProxyError> {
+    let mut outbound = connect_to_target(config).await?;
+    tokio::select! {
+        res = copy_bidirectional(&mut inbound, &mut outbound) => match res {
+            Ok(_) => Ok(()),
+            Err(e) if is_benign(&e) => Ok(()),
+            Err(e) => Err(ProxyError::Connection(format!("relay: {e}"))),
+        },
+        _ = cancel.cancelled() => Ok(()),
+    }
+}
+
+fn is_benign(err: &std::io::Error) -> bool {
+    matches!(
+        err.kind(),
+        std::io::ErrorKind::BrokenPipe
+            | std::io::ErrorKind::ConnectionReset
+            | std::io::ErrorKind::ConnectionAborted
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use tokio::io::AsyncWriteExt;
+    use tokio::net::TcpListener;
+
+    use super::*;
+    use crate::proxy::config::ProxyType;
+
+    async fn setup() -> (TcpStream, TcpStream, ProxyConfig) {
+        let target = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let target_addr = target.local_addr().unwrap();
+        tokio::spawn(async move {
+            loop {
+                if target.accept().await.is_err() {
+                    break;
+                }
+            }
+        });
+
+        let cfg = ProxyConfig::builder()
+            .target_host("127.0.0.1".into())
+            .target_port(target_addr.port())
+            .proxy_port(0)
+            .proxy_type(ProxyType::Tcp)
+            .build()
+            .unwrap();
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let accept = tokio::spawn(async move {
+            let (s, _) = listener.accept().await.unwrap();
+            s
+        });
+        let client = TcpStream::connect(addr).await.unwrap();
+        let server_side = accept.await.unwrap();
+        (client, server_side, cfg)
+    }
+
+    #[tokio::test]
+    async fn client_eof_completes_relay() {
+        let (mut client, server_side, cfg) = setup().await;
+        let cancel = CancellationToken::new();
+        client.shutdown().await.unwrap();
+        drop(client);
+        let res = tokio::time::timeout(
+            Duration::from_secs(2),
+            relay_direct(server_side, &cfg, cancel),
+        )
+        .await
+        .expect("relay should finish");
+        assert!(res.is_ok());
+    }
+
+    #[tokio::test]
+    async fn target_eof_completes_relay() {
+        let (mut client, server_side, cfg) = setup().await;
+        let cancel = CancellationToken::new();
+        client.shutdown().await.unwrap();
+        drop(client);
+        let res = tokio::time::timeout(
+            Duration::from_secs(2),
+            relay_direct(server_side, &cfg, cancel),
+        )
+        .await
+        .expect("relay should finish");
+        assert!(res.is_ok());
+    }
+
+    #[tokio::test]
+    async fn cancellation_aborts_relay() {
+        let (_client, server_side, cfg) = setup().await;
+        let cancel = CancellationToken::new();
+        let cancel_clone = cancel.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            cancel_clone.cancel();
+        });
+        let res = tokio::time::timeout(
+            Duration::from_secs(2),
+            relay_direct(server_side, &cfg, cancel),
+        )
+        .await
+        .expect("relay should finish");
+        assert!(res.is_ok());
+    }
+}

--- a/crates/kftray-server/src/proxy/sniff.rs
+++ b/crates/kftray-server/src/proxy/sniff.rs
@@ -1,0 +1,128 @@
+//! Non-destructive protocol sniffing for the TCP proxy dispatcher.
+//!
+//! Uses `TcpStream::peek` so the inbound stream is left untouched and can be
+//! handed to a hyper server (HTTP) or a raw byte-pump (TLS / unknown) without
+//! a buffered-prefix wrapper.
+
+use std::io;
+
+use tokio::net::TcpStream;
+
+/// Result of sniffing the first bytes of a freshly accepted TCP connection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Protocol {
+    /// HTTP/1.x request (detected by a known method token).
+    Http1,
+    /// HTTP/2 cleartext preface (`PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n`).
+    Http2,
+    /// TLS ClientHello (handshake record, version >= TLS 1.0).
+    Tls,
+    /// Anything else, including empty / slow openers.
+    Unknown,
+}
+
+const PEEK_LEN: usize = 32;
+const HTTP2_PREFACE: &[u8] = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
+
+/// Classify the protocol of an inbound connection by peeking at up to 32 bytes.
+///
+/// Blocks until the client sends its first byte (or closes). This is critical
+/// for the K8s WS port-forward case, where the apiserver pre-allocates many
+/// inbound TCPs at handshake but data only flows on them later as the client
+/// routes browser TCPs through multiplexed channels. A premature timeout would
+/// misclassify every idle pre-allocated slot as Unknown and bypass HTTP-aware
+/// dispatch entirely.
+///
+/// Returns the detected protocol. The stream is not consumed; the caller may
+/// hand the same `TcpStream` to hyper or to a raw relay without any wrapper.
+pub async fn classify(stream: &TcpStream) -> io::Result<Protocol> {
+    let mut buf = [0u8; PEEK_LEN];
+    let n = stream.peek(&mut buf).await?;
+    let kind = classify_bytes(&buf[..n]);
+    tracing::trace!(?kind, peek_bytes = n, "sniff classified");
+    Ok(kind)
+}
+
+fn classify_bytes(b: &[u8]) -> Protocol {
+    if b.starts_with(HTTP2_PREFACE) {
+        return Protocol::Http2;
+    }
+    if is_http1_request_line(b) {
+        return Protocol::Http1;
+    }
+    if b.len() >= 3 && b[0] == 0x16 && b[1] == 0x03 {
+        return Protocol::Tls;
+    }
+    Protocol::Unknown
+}
+
+fn is_http1_request_line(b: &[u8]) -> bool {
+    const METHODS: &[&[u8]] = &[
+        b"GET ",
+        b"POST ",
+        b"PUT ",
+        b"HEAD ",
+        b"DELETE ",
+        b"OPTIONS ",
+        b"PATCH ",
+        b"CONNECT ",
+        b"TRACE ",
+    ];
+    METHODS.iter().any(|m| b.starts_with(m))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_get_returns_http1() {
+        assert_eq!(classify_bytes(b"GET /foo HTTP/1.1\r\n"), Protocol::Http1);
+    }
+
+    #[test]
+    fn classify_post_returns_http1() {
+        assert_eq!(classify_bytes(b"POST /x HTTP/1.1\r\n"), Protocol::Http1);
+    }
+
+    #[test]
+    fn classify_http2_preface_returns_http2() {
+        assert_eq!(classify_bytes(HTTP2_PREFACE), Protocol::Http2);
+    }
+
+    #[test]
+    fn classify_tls_clienthello_returns_tls() {
+        let bytes = [0x16, 0x03, 0x01, 0x00, 0xa0];
+        assert_eq!(classify_bytes(&bytes), Protocol::Tls);
+    }
+
+    #[test]
+    fn classify_random_bytes_returns_unknown() {
+        assert_eq!(classify_bytes(b"\x00\x01\x02\x03random"), Protocol::Unknown);
+    }
+
+    #[test]
+    fn classify_empty_returns_unknown() {
+        assert_eq!(classify_bytes(&[]), Protocol::Unknown);
+    }
+
+    #[tokio::test]
+    async fn classify_live_stream_http1() {
+        use tokio::io::AsyncWriteExt;
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            classify(&stream).await.unwrap()
+        });
+
+        let mut client = TcpStream::connect(addr).await.unwrap();
+        client.write_all(b"GET / HTTP/1.1\r\n").await.unwrap();
+
+        let result = server.await.unwrap();
+        assert_eq!(result, Protocol::Http1);
+    }
+}

--- a/crates/kftray-server/src/proxy/tcp.rs
+++ b/crates/kftray-server/src/proxy/tcp.rs
@@ -10,20 +10,24 @@ use log::{
     info,
     warn,
 };
-use socket2::SockRef;
 use tokio::{
-    io::copy_bidirectional,
     net::{
         TcpListener,
         TcpStream,
     },
     sync::Notify,
-    time::timeout,
 };
+use tokio_util::sync::CancellationToken;
 
 use crate::proxy::{
     config::ProxyConfig,
     error::ProxyError,
+    http_proxy::HttpProxy,
+    relay::relay_direct,
+    sniff::{
+        Protocol,
+        classify,
+    },
     traits::ProxyHandler,
 };
 
@@ -35,117 +39,28 @@ impl TcpProxy {
         Self
     }
 
-    async fn connect_to_target(&self, config: &ProxyConfig) -> Result<TcpStream, ProxyError> {
-        const CONNECTION_TIMEOUT: Duration = Duration::from_secs(5);
-
-        if let Some(ref resolved_ip) = config.resolved_ip {
-            info!(
-                "Attempting connection to resolved IP {}:{}",
-                resolved_ip, config.target_port
-            );
-            match timeout(
-                CONNECTION_TIMEOUT,
-                TcpStream::connect(format!("{}:{}", resolved_ip, config.target_port)),
-            )
-            .await
-            {
-                Ok(Ok(stream)) => {
-                    info!(
-                        "Connected to target via IP {}:{}",
-                        resolved_ip, config.target_port
-                    );
-                    apply_keepalive(&stream);
-                    return Ok(stream);
-                }
-                Ok(Err(e)) => {
-                    warn!(
-                        "Failed to connect to resolved IP {}: {}. Trying hostname fallback.",
-                        resolved_ip, e
-                    );
-                }
-                Err(_) => {
-                    warn!(
-                        "Connection timeout to resolved IP {}. Trying hostname fallback.",
-                        resolved_ip
-                    );
-                }
-            }
-        }
-
-        info!(
-            "Attempting connection to hostname {}:{}",
-            config.target_host, config.target_port
-        );
-        match timeout(
-            CONNECTION_TIMEOUT,
-            TcpStream::connect(format!("{}:{}", config.target_host, config.target_port)),
-        )
-        .await
-        {
-            Ok(Ok(stream)) => {
-                info!(
-                    "Connected to target via hostname {}:{}",
-                    config.target_host, config.target_port
-                );
-                apply_keepalive(&stream);
-                Ok(stream)
-            }
-            Ok(Err(e)) => {
-                error!("Failed to connect to target: {e}");
-                Err(ProxyError::Connection(format!(
-                    "Failed to connect to target: {e}"
-                )))
-            }
-            Err(_) => Err(ProxyError::Connection("Connection timeout".into())),
-        }
-    }
-
     async fn handle_tcp_connection(
-        &self, inbound: TcpStream, config: &ProxyConfig,
+        inbound: TcpStream, config: ProxyConfig, http_proxy: HttpProxy, cancel: CancellationToken,
     ) -> Result<(), ProxyError> {
-        let outbound = self.connect_to_target(config).await?;
-        let (mut inbound, mut outbound) = (inbound, outbound);
+        let _ = inbound.set_nodelay(true);
+        let protocol = classify(&inbound)
+            .await
+            .map_err(|e| ProxyError::Connection(format!("sniff: {e}")))?;
 
-        match copy_bidirectional(&mut inbound, &mut outbound).await {
-            Ok((from_client, from_server)) => {
-                info!(
-                    "Connection closed. Bytes from client: {from_client}, from server: {from_server}"
-                );
-                Ok(())
+        match protocol {
+            Protocol::Http1 => {
+                tracing::debug!(?protocol, "dispatch: http1");
+                http_proxy.serve_http1(inbound, cancel).await
             }
-            Err(e) if Self::is_connection_reset(&e) => {
-                info!("Connection closed by peer");
-                Ok(())
+            Protocol::Http2 => {
+                tracing::debug!(?protocol, "dispatch: http2");
+                http_proxy.serve_http2(inbound, cancel).await
             }
-            Err(e) => {
-                error!("Connection error: {e}");
-                Err(ProxyError::Io(e))
+            _ => {
+                tracing::debug!(?protocol, "dispatch: raw relay");
+                relay_direct(inbound, &config, cancel).await
             }
         }
-    }
-
-    fn is_connection_reset(error: &std::io::Error) -> bool {
-        matches!(
-            error.kind(),
-            std::io::ErrorKind::BrokenPipe
-                | std::io::ErrorKind::ConnectionReset
-                | std::io::ErrorKind::ConnectionAborted
-        )
-    }
-}
-
-fn apply_keepalive(stream: &TcpStream) {
-    let sock_ref = SockRef::from(stream);
-
-    let keepalive = socket2::TcpKeepalive::new()
-        .with_time(Duration::from_secs(60))
-        .with_interval(Duration::from_secs(10));
-
-    #[cfg(any(target_os = "linux", target_os = "macos"))]
-    let keepalive = keepalive.with_retries(3);
-
-    if let Err(e) = sock_ref.set_tcp_keepalive(&keepalive) {
-        warn!("Failed to set TCP keepalive on target connection: {}", e);
     }
 }
 
@@ -157,6 +72,16 @@ impl ProxyHandler for TcpProxy {
 
         info!("TCP Proxy started on port {}", config.proxy_port);
 
+        let http_proxy = HttpProxy::new(&config);
+
+        let cancel = CancellationToken::new();
+        let shutdown_cancel = cancel.clone();
+        let shutdown_notify = shutdown.clone();
+        let bridge = tokio::spawn(async move {
+            shutdown_notify.notified().await;
+            shutdown_cancel.cancel();
+        });
+
         let mut backoff_ms: u64 = 10;
 
         loop {
@@ -165,12 +90,13 @@ impl ProxyHandler for TcpProxy {
                     match accept_result {
                         Ok((stream, addr)) => {
                             info!("Accepted connection from {addr}");
-                            let config = config.clone();
-                            let proxy = self.clone();
                             backoff_ms = 10;
+                            let config = config.clone();
+                            let http_proxy = http_proxy.clone();
+                            let child_cancel = cancel.child_token();
 
                             tokio::spawn(async move {
-                                if let Err(e) = proxy.handle_tcp_connection(stream, &config).await {
+                                if let Err(e) = Self::handle_tcp_connection(stream, config, http_proxy, child_cancel).await {
                                     error!("Connection error for {addr}: {e}");
                                 }
                             });
@@ -181,8 +107,9 @@ impl ProxyHandler for TcpProxy {
                                 _ = tokio::time::sleep(Duration::from_millis(backoff_ms)) => {
                                     backoff_ms = (backoff_ms * 2).min(5000);
                                 }
-                                _ = shutdown.notified() => {
+                                _ = cancel.cancelled() => {
                                     info!("Shutdown signal received during backoff, stopping TCP proxy");
+                                    bridge.abort();
                                     return Ok(());
                                 }
                             }
@@ -190,13 +117,14 @@ impl ProxyHandler for TcpProxy {
                         }
                     }
                 }
-                _ = shutdown.notified() => {
+                _ = cancel.cancelled() => {
                     info!("Shutdown signal received, stopping TCP proxy");
                     break;
                 }
             }
         }
 
+        bridge.abort();
         Ok(())
     }
 }
@@ -233,7 +161,6 @@ mod tests {
         let shutdown = Arc::new(Notify::new());
         let shutdown_clone = shutdown.clone();
 
-        // Bind to 127.0.0.1:0 first to get an available port
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         drop(listener);
@@ -250,7 +177,6 @@ mod tests {
             let _ = proxy.start(config, shutdown).await;
         });
 
-        // Wait for the proxy to be ready
         assert!(
             test_utils::wait_for_port(addr).await,
             "Proxy failed to start"
@@ -261,12 +187,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_tcp_proxy_echo() {
-        // Arrange
         let (echo_server, shutdown, proxy_addr) = setup_proxy().await;
-        let test_data = b"Hello, proxy!";
+        let test_data = b"\x01\x02\x03Hello, proxy!";
         let mut response = vec![0; test_data.len()];
 
-        // Act
         let mut stream = TcpStream::connect(proxy_addr).await.unwrap();
         stream.write_all(test_data).await.unwrap();
         stream.flush().await.unwrap();
@@ -276,23 +200,19 @@ mod tests {
             .unwrap()
             .unwrap();
 
-        // Assert
         assert_eq!(n, test_data.len());
         assert_eq!(&response, test_data);
 
-        // Cleanup
         shutdown.notify_one();
         echo_server.shutdown();
     }
 
     #[tokio::test]
     async fn test_tcp_proxy_large_data() {
-        // Arrange
         let (echo_server, shutdown, proxy_addr) = setup_proxy().await;
-        let test_data = vec![0x55; 1024 * 1024]; // 1MB of data
+        let test_data = vec![0x55; 1024 * 1024];
         let mut response = vec![0; test_data.len()];
 
-        // Act
         let mut stream = TcpStream::connect(proxy_addr).await.unwrap();
         stream.write_all(&test_data).await.unwrap();
         stream.flush().await.unwrap();
@@ -302,24 +222,20 @@ mod tests {
             .unwrap()
             .unwrap();
 
-        // Assert
         assert_eq!(n, test_data.len());
         assert_eq!(response, test_data);
 
-        // Cleanup
         shutdown.notify_one();
         echo_server.shutdown();
     }
 
     #[tokio::test]
     async fn test_tcp_proxy_multiple_clients() {
-        // Arrange
         let (echo_server, shutdown, proxy_addr) = setup_proxy().await;
-        let test_data = b"Hello from client";
+        let test_data = b"\x00\x01Hello from client";
         let client_count = 5;
         let mut handles = Vec::new();
 
-        // Act
         for i in 0..client_count {
             let addr = proxy_addr;
             let data = test_data.to_vec();
@@ -334,7 +250,6 @@ mod tests {
             }));
         }
 
-        // Assert
         for handle in handles {
             let (client_id, n, response) = handle.await.unwrap();
             assert_eq!(
@@ -348,33 +263,111 @@ mod tests {
             );
         }
 
-        // Cleanup
         shutdown.notify_one();
         echo_server.shutdown();
     }
 
     #[tokio::test]
     async fn test_target_connection_has_keepalive() {
-        // Arrange
         let (echo_server, shutdown, proxy_addr) = setup_proxy().await;
 
-        // Act - Connect through proxy to target
         let mut stream = TcpStream::connect(proxy_addr).await.unwrap();
-        stream.write_all(b"test").await.unwrap();
+        stream.write_all(b"\x00\x00\x00test").await.unwrap();
         stream.flush().await.unwrap();
 
-        // Read response to ensure connection is established
-        let mut buf = [0; 4];
+        let mut buf = [0; 7];
         let _ = stream.read_exact(&mut buf).await;
 
-        // Assert - The test verifies that keepalive was applied without errors
-        // If keepalive failed, the error would have been logged but connection would
-        // still work This test passes if the proxy successfully connects and
-        // applies keepalive
-
-        // Cleanup
         shutdown.notify_one();
         echo_server.shutdown();
+    }
+
+    #[tokio::test]
+    async fn test_http_traffic_through_proxy_uses_pool_correctly() {
+        use http_body_util::{
+            BodyExt,
+            Empty,
+        };
+        use hyper::body::{
+            Bytes,
+            Incoming,
+        };
+        use hyper::server::conn::http1;
+        use hyper::service::service_fn;
+        use hyper::{
+            Request,
+            Response,
+        };
+        use hyper_util::rt::TokioIo;
+
+        let http_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let http_addr = http_listener.local_addr().unwrap();
+
+        tokio::spawn(async move {
+            loop {
+                let (sock, _) = match http_listener.accept().await {
+                    Ok(v) => v,
+                    Err(_) => return,
+                };
+                tokio::spawn(async move {
+                    let io = TokioIo::new(sock);
+                    let svc = service_fn(|_req: Request<Incoming>| async move {
+                        Ok::<_, hyper::Error>(
+                            Response::builder()
+                                .status(200)
+                                .body(Empty::<Bytes>::new())
+                                .unwrap(),
+                        )
+                    });
+                    let _ = http1::Builder::new()
+                        .keep_alive(true)
+                        .serve_connection(io, svc)
+                        .await;
+                });
+            }
+        });
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let proxy_addr = listener.local_addr().unwrap();
+        drop(listener);
+
+        let config = ProxyConfig::builder()
+            .target_host("127.0.0.1".into())
+            .target_port(http_addr.port())
+            .proxy_port(proxy_addr.port())
+            .proxy_type(ProxyType::Tcp)
+            .build()
+            .unwrap();
+
+        let proxy = TcpProxy::new();
+        let shutdown = Arc::new(Notify::new());
+        let shutdown_clone = shutdown.clone();
+        tokio::spawn(async move {
+            let _ = proxy.start(config, shutdown).await;
+        });
+        assert!(test_utils::wait_for_port(proxy_addr).await);
+
+        for _ in 0..5 {
+            let stream = TcpStream::connect(proxy_addr).await.unwrap();
+            let io = TokioIo::new(stream);
+            let (mut sender, conn) = hyper::client::conn::http1::handshake::<_, Empty<Bytes>>(io)
+                .await
+                .unwrap();
+            tokio::spawn(async move {
+                let _ = conn.await;
+            });
+            let req = Request::builder()
+                .method("GET")
+                .uri("/")
+                .header("host", "test")
+                .body(Empty::<Bytes>::new())
+                .unwrap();
+            let resp = sender.send_request(req).await.unwrap();
+            assert_eq!(resp.status(), 200);
+            let _ = resp.into_body().collect().await;
+        }
+
+        shutdown_clone.notify_one();
     }
 
     #[test]


### PR DESCRIPTION
## Stack Context

This stack restructures the `websocket-pf` branch into 11 atomic PRs.
The goal is to extract a standalone `kube-portforward` crate (OSS-ready
WebSocket port-forwarder for Kubernetes) and rebuild kftray's port-forward
path on top of it, with a new HTTP proxy in kftray-server.

Stack order (bottom to top):
1. ws-pf/dev-tooling — dev tooling and gitignore
2. ws-pf/workspace-deps — workspace dependency consolidation
3. ws-pf/kube-portforward-crate — new kube-portforward crate
4. ws-pf/portforward-deps — wire kftray-portforward to new crate
5. ws-pf/ssl-platform-cleanup — remove dead SSL platform code
6. ws-pf/server-http-proxy — HTTP proxy with relay and sniffer
7. ws-pf/kube-registry-refactor — registry + kube listener rebuilt
8. ws-pf/expose-updates — expose flows through new registry
9. ws-pf/network-monitor-fix — PortForwardError type fix
10. ws-pf/tauri-integration — tauri command wiring
11. ws-pf/kftui-integration — kftui integration (top)

## Why?

kftray-server's TCP proxy was a pass-through: it couldn't distinguish HTTP from raw TCP or handle HTTP CONNECT tunneling. `sniff.rs` detects the protocol from the first bytes, `relay.rs` handles CONNECT proxy semantics, and `http_proxy.rs` wires them together. Also migrates logging from `env_logger` to `tracing` for structured output.

## What?

- new `proxy/http_proxy.rs`, `proxy/relay.rs`, `proxy/sniff.rs`
- modified `proxy/tcp.rs`, `main.rs`, `Cargo.toml`
