### PR TITLE
refactor(expose): wire expose flows through new registry

### DIFF
--- a/crates/kftray-portforward/src/expose/kubernetes.rs
+++ b/crates/kftray-portforward/src/expose/kubernetes.rs
@@ -33,6 +33,7 @@ use crate::expose::{
     models::ExposeResources,
     templates,
 };
+use crate::port_forward_error::PortForwardError;
 
 /// Extracts the first part of a domain name (before the first dot) to use as a
 /// DNS-1035 compliant name For example: "testelocal.ideia.totvs.io" ->
@@ -43,7 +44,7 @@ fn extract_subdomain(domain: &str) -> String {
 
 pub async fn create_expose_resources(
     client: Client, config: &Config,
-) -> Result<ExposeResources, String> {
+) -> Result<ExposeResources, PortForwardError> {
     let config_id_str = config
         .id
         .map_or_else(|| "default".to_string(), |id| id.to_string());
@@ -62,7 +63,7 @@ pub async fn create_expose_resources(
 
     let timestamp = SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .map_err(|e| e.to_string())?
+        .map_err(|e| PortForwardError::Expose(e.to_string()))?
         .as_secs();
 
     let random_string: String = {
@@ -90,10 +91,9 @@ pub async fn create_expose_resources(
     );
 
     // For public exposure, use the first part of the domain (before the first dot)
-    // as the service/ingress name For example: "testelocal.ideia.totvs.io"
-    // becomes "testelocal" This ensures DNS-1035 compliance for Kubernetes
-    // resource names
-    let service_name = if config.exposure_type.as_deref() == Some("public") {
+    // as the resource name. E.g. "testelocal.ideia.totvs.io" -> "testelocal"
+    // This ensures DNS-1035 compliance for Kubernetes resource names.
+    let resource_name = if config.exposure_type.as_deref() == Some("public") {
         config
             .alias
             .as_ref()
@@ -106,18 +106,8 @@ pub async fn create_expose_resources(
             .unwrap_or_else(|| deployment_name.clone())
     };
 
-    let ingress_name = if config.exposure_type.as_deref() == Some("public") {
-        config
-            .alias
-            .as_ref()
-            .map(|alias| extract_subdomain(alias))
-            .unwrap_or_else(|| deployment_name.clone())
-    } else {
-        config
-            .alias
-            .clone()
-            .unwrap_or_else(|| deployment_name.clone())
-    };
+    let service_name = resource_name.clone();
+    let ingress_name = resource_name;
 
     create_deployment(
         &client,
@@ -171,7 +161,7 @@ pub async fn create_expose_resources(
 
 async fn create_deployment(
     client: &Client, namespace: &str, deployment_name: &str, config_id: &str, config: &Config,
-) -> Result<(), String> {
+) -> Result<(), PortForwardError> {
     let deployments: Api<Deployment> = Api::namespaced(client.clone(), namespace);
 
     let local_port = config.local_port.unwrap_or(8080).to_string();
@@ -186,12 +176,12 @@ async fn create_deployment(
     let rendered = templates::render_template(&template, &values);
 
     let deployment: Deployment = serde_json::from_str(&rendered)
-        .map_err(|e| format!("Failed to parse deployment: {}", e))?;
+        .map_err(|e| PortForwardError::Expose(format!("Failed to parse deployment: {}", e)))?;
 
     deployments
         .create(&PostParams::default(), &deployment)
         .await
-        .map_err(|e| format!("Failed to create deployment: {}", e))?;
+        .map_err(|e| PortForwardError::Expose(format!("Failed to create deployment: {}", e)))?;
 
     info!("Deployment created successfully");
     Ok(())
@@ -199,7 +189,7 @@ async fn create_deployment(
 
 async fn wait_for_pod_ready(
     client: &Client, namespace: &str, config_id: &str,
-) -> Result<String, String> {
+) -> Result<String, PortForwardError> {
     let pods: Api<Pod> = Api::namespaced(client.clone(), namespace);
     let lp = ListParams::default().labels(&format!("app=kftray-expose,config_id={}", config_id));
 
@@ -208,35 +198,47 @@ async fn wait_for_pod_ready(
     let pod_list = pods
         .list(&lp)
         .await
-        .map_err(|e| format!("Failed to list pods: {}", e))?;
+        .map_err(|e| PortForwardError::Expose(format!("Failed to list pods: {}", e)))?;
 
-    let pod = pod_list.items.first().ok_or("No pod found")?;
+    let pod = pod_list
+        .items
+        .first()
+        .ok_or_else(|| PortForwardError::Expose("No pod found".to_string()))?;
 
-    let pod_name = pod.metadata.name.clone().ok_or("Pod has no name")?;
+    let pod_name = pod
+        .metadata
+        .name
+        .clone()
+        .ok_or_else(|| PortForwardError::Expose("Pod has no name".to_string()))?;
 
     kube_runtime::wait::await_condition(pods.clone(), &pod_name, conditions::is_pod_running())
         .await
-        .map_err(|e| format!("Pod not ready: {}", e))?;
+        .map_err(|e| PortForwardError::Expose(format!("Pod not ready: {}", e)))?;
 
     info!("Pod ready: {}", pod_name);
     Ok(pod_name)
 }
 
-async fn get_pod_ip(client: &Client, namespace: &str, pod_name: &str) -> Result<String, String> {
+async fn get_pod_ip(
+    client: &Client, namespace: &str, pod_name: &str,
+) -> Result<String, PortForwardError> {
     let pods: Api<Pod> = Api::namespaced(client.clone(), namespace);
     let pod = pods
         .get(pod_name)
         .await
-        .map_err(|e| format!("Failed to get pod: {}", e))?;
+        .map_err(|e| PortForwardError::Expose(format!("Failed to get pod: {}", e)))?;
 
-    let pod_ip = pod.status.and_then(|s| s.pod_ip).ok_or("Pod has no IP")?;
+    let pod_ip = pod
+        .status
+        .and_then(|s| s.pod_ip)
+        .ok_or_else(|| PortForwardError::Expose("Pod has no IP".to_string()))?;
 
     Ok(pod_ip)
 }
 
 async fn create_service(
     client: &Client, namespace: &str, service_name: &str, config_id: &str, local_port: u16,
-) -> Result<(), String> {
+) -> Result<(), PortForwardError> {
     let services: Api<Service> = Api::namespaced(client.clone(), namespace);
 
     let mut values = HashMap::new();
@@ -248,13 +250,13 @@ async fn create_service(
     let template = templates::load_service_template()?;
     let rendered = templates::render_template(&template, &values);
 
-    let service: Service =
-        serde_json::from_str(&rendered).map_err(|e| format!("Failed to parse service: {}", e))?;
+    let service: Service = serde_json::from_str(&rendered)
+        .map_err(|e| PortForwardError::Expose(format!("Failed to parse service: {}", e)))?;
 
     services
         .create(&PostParams::default(), &service)
         .await
-        .map_err(|e| format!("Failed to create service: {}", e))?;
+        .map_err(|e| PortForwardError::Expose(format!("Failed to create service: {}", e)))?;
 
     info!("Service created successfully");
     Ok(())
@@ -262,13 +264,15 @@ async fn create_service(
 
 async fn create_ingress(
     client: &Client, namespace: &str, ingress_name: &str, service_name: &str, config: &Config,
-) -> Result<(), String> {
+) -> Result<(), PortForwardError> {
     let ingresses: Api<Ingress> = Api::namespaced(client.clone(), namespace);
 
     let domain = config
         .alias
         .as_ref()
-        .ok_or("Domain not configured for public exposure (set alias field)")?;
+        .ok_or_else(|| PortForwardError::ConfigurationError {
+            message: "Domain not configured for public exposure (set alias field)".to_string(),
+        })?;
 
     let config_id_str = config
         .id
@@ -300,13 +304,13 @@ async fn create_ingress(
     let template = templates::load_ingress_template()?;
     let rendered = templates::render_template(&template, &values);
 
-    let ingress: Ingress =
-        serde_json::from_str(&rendered).map_err(|e| format!("Failed to parse ingress: {}", e))?;
+    let ingress: Ingress = serde_json::from_str(&rendered)
+        .map_err(|e| PortForwardError::Expose(format!("Failed to parse ingress: {}", e)))?;
 
     ingresses
         .create(&PostParams::default(), &ingress)
         .await
-        .map_err(|e| format!("Failed to create ingress: {}", e))?;
+        .map_err(|e| PortForwardError::Expose(format!("Failed to create ingress: {}", e)))?;
 
     info!("Created ingress");
     Ok(())
@@ -339,7 +343,7 @@ async fn check_existing_resources(
 
 pub async fn delete_expose_resources(
     client: Client, namespace: &str, config_id_label: &str,
-) -> Result<(), String> {
+) -> Result<(), PortForwardError> {
     let label_selector = format!("app=kftray-expose,config_id={}", config_id_label);
     let lp = ListParams::default().labels(&label_selector);
 
@@ -359,7 +363,9 @@ pub async fn delete_expose_resources(
     Ok(())
 }
 
-async fn delete_ingresses(client: &Client, namespace: &str, lp: &ListParams) -> Result<(), String> {
+async fn delete_ingresses(
+    client: &Client, namespace: &str, lp: &ListParams,
+) -> Result<(), PortForwardError> {
     let api: Api<Ingress> = Api::namespaced(client.clone(), namespace);
 
     let items = match api.list(lp).await {
@@ -387,7 +393,9 @@ async fn delete_ingresses(client: &Client, namespace: &str, lp: &ListParams) -> 
     Ok(())
 }
 
-async fn delete_services(client: &Client, namespace: &str, lp: &ListParams) -> Result<(), String> {
+async fn delete_services(
+    client: &Client, namespace: &str, lp: &ListParams,
+) -> Result<(), PortForwardError> {
     let api: Api<Service> = Api::namespaced(client.clone(), namespace);
 
     let items = match api.list(lp).await {
@@ -417,7 +425,7 @@ async fn delete_services(client: &Client, namespace: &str, lp: &ListParams) -> R
 
 async fn delete_deployments(
     client: &Client, namespace: &str, lp: &ListParams,
-) -> Result<(), String> {
+) -> Result<(), PortForwardError> {
     let api: Api<Deployment> = Api::namespaced(client.clone(), namespace);
 
     let items = match api.list(lp).await {

--- a/crates/kftray-portforward/src/expose/mod.rs
+++ b/crates/kftray-portforward/src/expose/mod.rs
@@ -15,15 +15,17 @@ use log::{
     info,
 };
 
-use crate::kube::shared_client::{
-    SHARED_CLIENT_MANAGER,
-    ServiceClientKey,
+use crate::kube::shared_client::ServiceClientKey;
+use crate::port_forward_error::PortForwardError;
+use crate::registry::{
+    PORT_FORWARD_REGISTRY,
+    PortForwardKey,
 };
 
 /// Start expose for given configs
 pub async fn start_expose(
     configs: Vec<Config>, mode: DatabaseMode,
-) -> Result<Vec<CustomResponse>, String> {
+) -> Result<Vec<CustomResponse>, PortForwardError> {
     let mut responses = Vec::new();
 
     for config in configs {
@@ -36,7 +38,9 @@ pub async fn start_expose(
     Ok(responses)
 }
 
-async fn start_single_expose(config: Config, mode: DatabaseMode) -> Result<CustomResponse, String> {
+async fn start_single_expose(
+    config: Config, mode: DatabaseMode,
+) -> Result<CustomResponse, PortForwardError> {
     use self::kubernetes::create_expose_resources;
     use self::websocket_client::WebSocketTunnelClient;
     use crate::kube::models::{
@@ -46,15 +50,18 @@ async fn start_single_expose(config: Config, mode: DatabaseMode) -> Result<Custo
         Target,
         TargetSelector,
     };
-    use crate::port_forward::CHILD_PROCESSES;
 
-    let config_id = config.id.ok_or("Config has no ID")?;
+    let config_id = config
+        .id
+        .ok_or_else(|| PortForwardError::ConfigurationError {
+            message: "Config has no ID".to_string(),
+        })?;
 
     let client_key = ServiceClientKey::new(config.context.clone(), config.kubeconfig.clone());
-    let client = SHARED_CLIENT_MANAGER
-        .get_client(client_key)
+    let client = PORT_FORWARD_REGISTRY
+        .acquire_client(client_key.clone())
         .await
-        .map_err(|e| format!("Failed to get K8s client: {}", e))?;
+        .map_err(|e| PortForwardError::KubeApi(format!("Failed to get K8s client: {}", e)))?;
     let client = (*client).clone();
 
     info!("Creating expose resources for config {}", config_id);
@@ -82,19 +89,21 @@ async fn start_single_expose(config: Config, mode: DatabaseMode) -> Result<Custo
         "expose".to_string(),
     )
     .await
-    .map_err(|e| format!("Failed to create port-forward: {}", e))?;
+    .map_err(|e| PortForwardError::Expose(format!("Failed to create port-forward: {}", e)))?;
 
     let (websocket_port, pf_process) = port_forward
         .port_forward_tcp(None)
         .await
-        .map_err(|e| format!("Failed to start port-forward: {}", e))?;
+        .map_err(|e| PortForwardError::Expose(format!("Failed to start port-forward: {}", e)))?;
 
     info!(
         "Port-forward established: localhost:{} → pod:9999",
         websocket_port
     );
 
-    CHILD_PROCESSES.insert(config_id.to_string(), pf_process);
+    let ws_cancel = pf_process.cancellation_token.clone();
+    let pf_key = PortForwardKey::expose(config_id);
+    PORT_FORWARD_REGISTRY.insert_process(pf_key.clone(), pf_process, client_key);
 
     let local_service_port = config.local_port.unwrap_or(8080);
     let local_service_address = config
@@ -113,15 +122,15 @@ async fn start_single_expose(config: Config, mode: DatabaseMode) -> Result<Custo
     );
 
     let ws_handle = tokio::spawn(async move {
-        if let Err(e) = ws_client.start().await {
+        if let Err(e) = ws_client.start(ws_cancel).await {
             error!("WebSocket client error: {}", e);
         }
     });
 
     // Store the WebSocket client handle so it can be aborted when stopping
-    if let Some(mut process) = CHILD_PROCESSES.get_mut(&config_id.to_string()) {
-        process.set_ws_client_handle(ws_handle);
-    }
+    PORT_FORWARD_REGISTRY.with_process_mut(&pf_key, |entry| {
+        entry.process.set_ws_client_handle(ws_handle);
+    });
 
     let config_state = ConfigState {
         id: None,
@@ -152,26 +161,26 @@ async fn start_single_expose(config: Config, mode: DatabaseMode) -> Result<Custo
 
 pub async fn stop_expose(
     config_id: i64, namespace: &str, mode: DatabaseMode,
-) -> Result<CustomResponse, String> {
+) -> Result<CustomResponse, PortForwardError> {
     use kftray_commons::utils::config::get_config_with_mode;
 
     use self::kubernetes::delete_expose_resources;
-    use crate::port_forward::CHILD_PROCESSES;
 
     info!("Stopping expose for config {}", config_id);
 
     let config = get_config_with_mode(config_id, mode).await?;
 
-    if let Some((_, pf_process)) = CHILD_PROCESSES.remove(&config_id.to_string()) {
+    let pf_key = PortForwardKey::expose(config_id);
+    if let Some(entry) = PORT_FORWARD_REGISTRY.remove_process(&pf_key) {
         info!("Cleaning up port-forward for config {}", config_id);
-        pf_process.cleanup_and_abort().await;
+        entry.process.cleanup_and_abort().await;
     }
 
     let client_key = ServiceClientKey::new(config.context.clone(), config.kubeconfig.clone());
-    let client = SHARED_CLIENT_MANAGER
-        .get_client(client_key)
+    let client = PORT_FORWARD_REGISTRY
+        .acquire_client(client_key)
         .await
-        .map_err(|e| format!("Failed to get K8s client: {}", e))?;
+        .map_err(|e| PortForwardError::KubeApi(format!("Failed to get K8s client: {}", e)))?;
     let client = (*client).clone();
 
     delete_expose_resources(client, namespace, &config_id.to_string()).await?;

--- a/crates/kftray-portforward/src/expose/templates.rs
+++ b/crates/kftray-portforward/src/expose/templates.rs
@@ -8,6 +8,8 @@ use kftray_commons::utils::config_dir::{
     get_expose_service_manifest_path,
 };
 
+use crate::port_forward_error::PortForwardError;
+
 pub fn render_template(template: &str, values: &HashMap<&str, String>) -> String {
     let mut rendered = template.to_string();
     for (key, value) in values {
@@ -16,49 +18,34 @@ pub fn render_template(template: &str, values: &HashMap<&str, String>) -> String
     rendered
 }
 
-pub fn load_deployment_template() -> Result<String, String> {
-    let manifest_path = get_expose_deployment_manifest_path()
-        .map_err(|e| format!("Failed to get manifest path: {}", e))?;
-    let mut file = File::open(&manifest_path).map_err(|e| {
-        format!(
-            "Failed to open expose deployment manifest at {:?}: {}",
-            manifest_path, e
-        )
+fn load_template(
+    get_path: fn() -> Result<std::path::PathBuf, String>, kind: &str,
+) -> Result<String, PortForwardError> {
+    let manifest_path = get_path().map_err(|e| PortForwardError::ConfigurationError {
+        message: format!("Failed to get {kind} manifest path: {e}"),
     })?;
+    let mut file =
+        File::open(&manifest_path).map_err(|e| PortForwardError::ConfigurationError {
+            message: format!("Failed to open {kind} manifest at {manifest_path:?}: {e}"),
+        })?;
     let mut contents = String::new();
     file.read_to_string(&mut contents)
-        .map_err(|e| format!("Failed to read manifest: {}", e))?;
+        .map_err(|e| PortForwardError::ConfigurationError {
+            message: format!("Failed to read {kind} manifest: {e}"),
+        })?;
     Ok(contents)
 }
 
-pub fn load_service_template() -> Result<String, String> {
-    let manifest_path = get_expose_service_manifest_path()
-        .map_err(|e| format!("Failed to get manifest path: {}", e))?;
-    let mut file = File::open(&manifest_path).map_err(|e| {
-        format!(
-            "Failed to open expose service manifest at {:?}: {}",
-            manifest_path, e
-        )
-    })?;
-    let mut contents = String::new();
-    file.read_to_string(&mut contents)
-        .map_err(|e| format!("Failed to read manifest: {}", e))?;
-    Ok(contents)
+pub fn load_deployment_template() -> Result<String, PortForwardError> {
+    load_template(get_expose_deployment_manifest_path, "deployment")
 }
 
-pub fn load_ingress_template() -> Result<String, String> {
-    let manifest_path = get_expose_ingress_manifest_path()
-        .map_err(|e| format!("Failed to get manifest path: {}", e))?;
-    let mut file = File::open(&manifest_path).map_err(|e| {
-        format!(
-            "Failed to open expose ingress manifest at {:?}: {}",
-            manifest_path, e
-        )
-    })?;
-    let mut contents = String::new();
-    file.read_to_string(&mut contents)
-        .map_err(|e| format!("Failed to read manifest: {}", e))?;
-    Ok(contents)
+pub fn load_service_template() -> Result<String, PortForwardError> {
+    load_template(get_expose_service_manifest_path, "service")
+}
+
+pub fn load_ingress_template() -> Result<String, PortForwardError> {
+    load_template(get_expose_ingress_manifest_path, "ingress")
 }
 
 pub fn build_ingress_annotations(
@@ -81,15 +68,12 @@ pub fn build_ingress_annotations(
 
     if let Some(json_str) = additional_annotations
         && !json_str.trim().is_empty()
+        && let Ok(parsed) = serde_json::from_str::<serde_json::Value>(json_str)
+        && let Some(obj) = parsed.as_object()
     {
-        // Try to parse as JSON object
-        if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(json_str)
-            && let Some(obj) = parsed.as_object()
-        {
-            for (key, value) in obj {
-                if let Some(val_str) = value.as_str() {
-                    annotations.push(format!(r#""{}": "{}""#, key, val_str));
-                }
+        for (key, value) in obj {
+            if let Some(val_str) = value.as_str() {
+                annotations.push(format!(r#""{}": "{}""#, key, val_str));
             }
         }
     }

--- a/crates/kftray-portforward/src/expose/websocket_client.rs
+++ b/crates/kftray-portforward/src/expose/websocket_client.rs
@@ -28,6 +28,9 @@ use tokio_tungstenite::{
     connect_async,
     tungstenite::Message,
 };
+use tokio_util::sync::CancellationToken;
+
+use crate::port_forward_error::PortForwardError;
 
 pub struct WebSocketTunnelClient {
     websocket_port: u16,
@@ -46,12 +49,17 @@ impl WebSocketTunnelClient {
         }
     }
 
-    pub async fn start(&self) -> Result<(), String> {
+    pub async fn start(&self, cancel: CancellationToken) -> Result<(), PortForwardError> {
         let ws_url = format!("ws://127.0.0.1:{}", self.websocket_port);
         let max_retries = 100;
         let mut retry_count = 0;
 
         loop {
+            if cancel.is_cancelled() {
+                info!("WebSocket tunnel cancelled before connect");
+                break;
+            }
+
             info!(
                 "Connecting WebSocket client to {} (attempt {}/{})",
                 ws_url,
@@ -59,21 +67,29 @@ impl WebSocketTunnelClient {
                 max_retries
             );
 
-            match self.connect_and_run(&ws_url).await {
-                Ok(_) => {
-                    info!("WebSocket tunnel disconnected gracefully");
+            tokio::select! {
+                _ = cancel.cancelled() => {
+                    info!("WebSocket tunnel cancelled during connect");
+                    break;
                 }
-                Err(e) => {
-                    error!("WebSocket tunnel error: {}", e);
+                result = self.connect_and_run(&ws_url) => {
+                    match result {
+                        Ok(_) => {
+                            info!("WebSocket tunnel disconnected gracefully");
+                        }
+                        Err(e) => {
+                            error!("WebSocket tunnel error: {}", e);
+                        }
+                    }
                 }
             }
 
             retry_count += 1;
             if retry_count >= max_retries {
-                return Err(format!(
+                return Err(PortForwardError::Expose(format!(
                     "Max reconnection attempts ({}) reached",
                     max_retries
-                ));
+                )));
             }
 
             let backoff_secs = std::cmp::min(2_u64.pow(retry_count.min(4)), 30);
@@ -81,15 +97,24 @@ impl WebSocketTunnelClient {
                 "WebSocket disconnected. Reconnecting in {} seconds...",
                 backoff_secs
             );
-            tokio::time::sleep(tokio::time::Duration::from_secs(backoff_secs)).await;
+
+            tokio::select! {
+                _ = cancel.cancelled() => {
+                    info!("WebSocket tunnel cancelled during backoff");
+                    break;
+                }
+                _ = tokio::time::sleep(tokio::time::Duration::from_secs(backoff_secs)) => {}
+            }
         }
+
+        Ok(())
     }
 
-    async fn connect_and_run(&self, ws_url: &str) -> Result<(), String> {
+    async fn connect_and_run(&self, ws_url: &str) -> Result<(), PortForwardError> {
         // Connect to the port-forwarded WebSocket endpoint
-        let (ws_stream, _) = connect_async(ws_url)
-            .await
-            .map_err(|e| format!("Failed to connect to WebSocket: {}", e))?;
+        let (ws_stream, _) = connect_async(ws_url).await.map_err(|e| {
+            PortForwardError::Expose(format!("Failed to connect to WebSocket: {}", e))
+        })?;
 
         info!("WebSocket tunnel connected");
 


### PR DESCRIPTION
## Stack Context

This stack restructures the `websocket-pf` branch into 11 atomic PRs.
The goal is to extract a standalone `kube-portforward` crate (OSS-ready
WebSocket port-forwarder for Kubernetes) and rebuild kftray's port-forward
path on top of it, with a new HTTP proxy in kftray-server.

Stack order (bottom to top):
1. ws-pf/dev-tooling — dev tooling and gitignore
2. ws-pf/workspace-deps — workspace dependency consolidation
3. ws-pf/kube-portforward-crate — new kube-portforward crate
4. ws-pf/portforward-deps — wire kftray-portforward to new crate
5. ws-pf/ssl-platform-cleanup — remove dead SSL platform code
6. ws-pf/server-http-proxy — HTTP proxy with relay and sniffer
7. ws-pf/kube-registry-refactor — registry + kube listener rebuilt
8. ws-pf/expose-updates — expose flows through new registry
9. ws-pf/network-monitor-fix — PortForwardError type fix
10. ws-pf/tauri-integration — tauri command wiring
11. ws-pf/kftui-integration — kftui integration (top)

## Why?

The expose module (reverse tunneling) referenced `CHILD_PROCESSES` directly. Now that `PORT_FORWARD_REGISTRY` is the authoritative state store, `expose/mod.rs` is updated to look up and register entries through the registry. The Kubernetes and template helpers also receive minor updates.

## What?

- modified `expose/kubernetes.rs`, `expose/mod.rs`, `expose/templates.rs`, `expose/websocket_client.rs`
