### PR TITLE
fix(network-monitor): adapt to PortForwardError type change

### DIFF
--- a/crates/kftray-network-monitor/src/config_manager.rs
+++ b/crates/kftray-network-monitor/src/config_manager.rs
@@ -87,7 +87,7 @@ impl ConfigManager {
             match kftray_portforward::kube::start_port_forward(other_configs, protocol).await {
                 Ok(_) => info!("Successfully restarted {protocol} port forwards"),
                 Err(e) => {
-                    if protocol == "udp" && e.contains("No ready pods available") {
+                    if protocol == "udp" && e.to_string().contains("No ready pods available") {
                         log::warn!(
                             "UDP port forward restart skipped - no ready pods available: {e}"
                         );


### PR DESCRIPTION
## Stack Context

This stack restructures the `websocket-pf` branch into 11 atomic PRs.
The goal is to extract a standalone `kube-portforward` crate (OSS-ready
WebSocket port-forwarder for Kubernetes) and rebuild kftray's port-forward
path on top of it, with a new HTTP proxy in kftray-server.

Stack order (bottom to top):
1. ws-pf/dev-tooling — dev tooling and gitignore
2. ws-pf/workspace-deps — workspace dependency consolidation
3. ws-pf/kube-portforward-crate — new kube-portforward crate
4. ws-pf/portforward-deps — wire kftray-portforward to new crate
5. ws-pf/ssl-platform-cleanup — remove dead SSL platform code
6. ws-pf/server-http-proxy — HTTP proxy with relay and sniffer
7. ws-pf/kube-registry-refactor — registry + kube listener rebuilt
8. ws-pf/expose-updates — expose flows through new registry
9. ws-pf/network-monitor-fix — PortForwardError type fix
10. ws-pf/tauri-integration — tauri command wiring
11. ws-pf/kftui-integration — kftui integration (top)

## Why?

`config_manager.rs` called `.contains()` on a `String` error. PR 7 changed the error type to `PortForwardError`, which doesn't implement `Contains`. Calling `.to_string()` first restores the original check behavior.

## What?

- `crates/kftray-network-monitor/src/config_manager.rs` (1 line)
