### PR TITLE
feat(tauri): wire commands and init to new port-forward registry

### DIFF
--- a/crates/kftray-tauri/Cargo.toml
+++ b/crates/kftray-tauri/Cargo.toml
@@ -18,12 +18,13 @@ path = "src/lib.rs"
 
 [dependencies]
 anyhow = { workspace = true }
+mimalloc = { workspace = true }
 async-trait = { workspace = true }
 dirs = { workspace = true }
 env_logger = { workspace = true }
 fix-path-env = { workspace = true }
 flexi_logger = { workspace = true }
-jiff = "0.2"
+jiff = { workspace = true }
 k8s-openapi = { workspace = true }
 keyring-core = { workspace = true }
 kftray-commons = { workspace = true }
@@ -35,6 +36,9 @@ kftray-shortcuts = { workspace = true }
 kube = { workspace = true }
 lazy_static = { workspace = true }
 log = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+tracing-log = "0.2"
 netstat2 = { workspace = true }
 open = { workspace = true }
 serde = { workspace = true }
@@ -67,10 +71,10 @@ kftray-helper = { workspace = true }
 tauri-build = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-inotify = "0.11.1"
-ksni = "0.3"
+inotify = { workspace = true }
+ksni = { workspace = true }
 libc = { workspace = true }
-png = "0.18"
+png = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { workspace = true }

--- a/crates/kftray-tauri/src/commands/kubecontext.rs
+++ b/crates/kftray-tauri/src/commands/kubecontext.rs
@@ -254,7 +254,9 @@ pub async fn get_services_with_annotations(
         "get_services_with_annotations called with context: '{context_name}' and kubeconfig: {kubeconfig_path:?}"
     );
 
-    retrieve_service_configs(&context_name, kubeconfig_path).await
+    retrieve_service_configs(&context_name, kubeconfig_path)
+        .await
+        .map_err(|e| e.to_string())
 }
 
 #[cfg(test)]

--- a/crates/kftray-tauri/src/commands/portforward.rs
+++ b/crates/kftray-tauri/src/commands/portforward.rs
@@ -132,35 +132,43 @@ fn config_compare_changes<T: PartialEq>(prev: &[T], current: &[T]) -> bool {
 pub async fn start_port_forward_udp_cmd(
     configs: Vec<Config>, _app_handle: tauri::AppHandle<Wry>,
 ) -> Result<Vec<CustomResponse>, String> {
-    start_port_forward(configs.clone(), "udp").await
+    start_port_forward(configs.clone(), "udp")
+        .await
+        .map_err(|e| e.to_string())
 }
 
 #[tauri::command]
 pub async fn start_port_forward_tcp_cmd(
     configs: Vec<Config>, _app_handle: tauri::AppHandle<Wry>,
 ) -> Result<Vec<CustomResponse>, String> {
-    start_port_forward(configs.clone(), "tcp").await
+    start_port_forward(configs.clone(), "tcp")
+        .await
+        .map_err(|e| e.to_string())
 }
 
 #[tauri::command]
 pub async fn stop_all_port_forward_cmd(
     _app_handle: tauri::AppHandle<Wry>,
 ) -> Result<Vec<CustomResponse>, String> {
-    stop_all_port_forward().await
+    stop_all_port_forward().await.map_err(|e| e.to_string())
 }
 
 #[tauri::command]
 pub async fn stop_port_forward_cmd(
     config_id: String, _app_handle: tauri::AppHandle<Wry>,
 ) -> Result<CustomResponse, String> {
-    stop_port_forward(config_id.clone()).await
+    stop_port_forward(config_id.clone())
+        .await
+        .map_err(|e| e.to_string())
 }
 
 #[tauri::command]
 pub async fn deploy_and_forward_pod_cmd(
     configs: Vec<Config>, _app_handle: tauri::AppHandle<Wry>,
 ) -> Result<Vec<CustomResponse>, String> {
-    deploy_and_forward_pod(configs.clone()).await
+    deploy_and_forward_pod(configs.clone())
+        .await
+        .map_err(|e| e.to_string())
 }
 
 #[tauri::command]
@@ -171,28 +179,20 @@ pub async fn stop_proxy_forward_cmd(
         .parse::<i64>()
         .map_err(|e| format!("Failed to parse config_id: {e}"))?;
 
-    stop_proxy_forward(config_id, namespace, service_name).await
+    stop_proxy_forward(config_id, namespace, service_name)
+        .await
+        .map_err(|e| e.to_string())
 }
 
 #[tauri::command]
 pub async fn get_active_pod_cmd(config_id: String) -> Result<Option<String>, String> {
-    use kftray_portforward::port_forward::CHILD_PROCESSES;
+    use kftray_portforward::registry::PORT_FORWARD_REGISTRY;
 
-    let handle_key = format!("config:{}:service:", config_id);
+    let config_id_parsed = config_id
+        .parse::<i64>()
+        .map_err(|e| format!("Failed to parse config_id: {e}"))?;
 
-    let matching_forwarders: Vec<_> = CHILD_PROCESSES
-        .iter()
-        .filter(|entry| entry.key().starts_with(&handle_key) || entry.key() == &config_id)
-        .filter_map(|entry| entry.value().direct_forwarder.clone())
-        .collect();
-
-    for forwarder in matching_forwarders {
-        if let Some(pod_name) = forwarder.get_current_active_pod().await {
-            return Ok(Some(pod_name));
-        }
-    }
-
-    Ok(None)
+    Ok(PORT_FORWARD_REGISTRY.get_active_pod(config_id_parsed).await)
 }
 
 #[tauri::command]

--- a/crates/kftray-tauri/src/init_check.rs
+++ b/crates/kftray-tauri/src/init_check.rs
@@ -66,12 +66,14 @@ impl PortOperations for RealPortOperations {
         start_port_forward(configs, protocol)
             .await
             .map(|responses| responses.into_iter().map(|r| format!("{r:?}")).collect())
+            .map_err(|e| e.to_string())
     }
 
     async fn deploy_and_forward_pod(&self, configs: Vec<Config>) -> Result<Vec<String>, String> {
         deploy_and_forward_pod(configs)
             .await
             .map(|responses| responses.into_iter().map(|r| format!("{r:?}")).collect())
+            .map_err(|e| e.to_string())
     }
 }
 

--- a/crates/kftray-tauri/src/main.rs
+++ b/crates/kftray-tauri/src/main.rs
@@ -3,6 +3,9 @@
     windows_subsystem = "windows"
 )]
 
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 use std::sync::Arc;
 
 use log::{
@@ -76,13 +79,27 @@ fn init_file_logger() -> anyhow::Result<()> {
         jiff::Zoned::now().strftime("%Y-%m-%d_%H-%M-%S")
     );
 
-    flexi_logger::Logger::try_with_str("info")?
+    // When RUST_LOG is set, mirror the same level to stdout so terminal output
+    // reflects the requested verbosity (e.g. RUST_LOG=trace mise run dev).
+    let stdout_duplicate = match std::env::var("RUST_LOG")
+        .unwrap_or_default()
+        .to_lowercase()
+        .as_str()
+    {
+        s if s.contains("trace") => flexi_logger::Duplicate::Trace,
+        s if s.contains("debug") => flexi_logger::Duplicate::Debug,
+        s if s.contains("warn") => flexi_logger::Duplicate::Warn,
+        s if s.contains("error") => flexi_logger::Duplicate::Error,
+        _ => flexi_logger::Duplicate::Info,
+    };
+
+    flexi_logger::Logger::try_with_env_or_str("info")?
         .log_to_file(
             flexi_logger::FileSpec::default()
                 .directory(log_dir)
                 .basename(basename),
         )
-        .duplicate_to_stdout(flexi_logger::Duplicate::Info)
+        .duplicate_to_stdout(stdout_duplicate)
         .rotate(
             flexi_logger::Criterion::Size(5_000_000),
             flexi_logger::Naming::Numbers,
@@ -90,6 +107,37 @@ fn init_file_logger() -> anyhow::Result<()> {
         )
         .format(flexi_logger::detailed_format)
         .start()?;
+
+    // Bridge `log` crate events (tungstenite, tokio-tungstenite, etc.) into
+    // `tracing` so a single subscriber handles everything.
+    // max_level matches RUST_LOG or falls back to Debug to avoid filtering
+    // out log:: calls before tracing's EnvFilter can evaluate them.
+    let max_log_level = match std::env::var("RUST_LOG")
+        .unwrap_or_default()
+        .to_lowercase()
+        .as_str()
+    {
+        s if s.contains("trace") => log::LevelFilter::Trace,
+        s if s.contains("debug") => log::LevelFilter::Debug,
+        _ => log::LevelFilter::Info,
+    };
+    tracing_log::LogTracer::builder()
+        .with_max_level(max_log_level)
+        .init()
+        .ok();
+
+    // Single tracing subscriber for both tracing:: and log:: events.
+    // RUST_LOG controls the filter (e.g. tungstenite=trace,kube=debug).
+    let rust_log = std::env::var("RUST_LOG").unwrap_or_else(|_| "info".to_string());
+    let filter = tracing_subscriber::EnvFilter::try_new(&rust_log)
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
+    tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_target(true)
+        .with_level(true)
+        .without_time() // flexi_logger already adds timestamps
+        .try_init()
+        .ok(); // ok() because another subscriber may already be installed
 
     Ok(())
 }
@@ -227,13 +275,13 @@ fn main() {
                 use std::time::Duration;
 
                 use kftray_portforward::kube::cleanup_stale_timeout_entries;
-                use kftray_portforward::kube::shared_client::SHARED_CLIENT_MANAGER;
+                use kftray_portforward::registry::PORT_FORWARD_REGISTRY;
 
                 let mut interval = tokio::time::interval(Duration::from_secs(3600));
                 loop {
                     interval.tick().await;
                     cleanup_stale_timeout_entries().await;
-                    SHARED_CLIENT_MANAGER.cleanup_expired();
+                    PORT_FORWARD_REGISTRY.cleanup_expired_clients();
                 }
             });
 


### PR DESCRIPTION
## Stack Context

This stack restructures the `websocket-pf` branch into 11 atomic PRs.
The goal is to extract a standalone `kube-portforward` crate (OSS-ready
WebSocket port-forwarder for Kubernetes) and rebuild kftray's port-forward
path on top of it, with a new HTTP proxy in kftray-server.

Stack order (bottom to top):
1. ws-pf/dev-tooling — dev tooling and gitignore
2. ws-pf/workspace-deps — workspace dependency consolidation
3. ws-pf/kube-portforward-crate — new kube-portforward crate
4. ws-pf/portforward-deps — wire kftray-portforward to new crate
5. ws-pf/ssl-platform-cleanup — remove dead SSL platform code
6. ws-pf/server-http-proxy — HTTP proxy with relay and sniffer
7. ws-pf/kube-registry-refactor — registry + kube listener rebuilt
8. ws-pf/expose-updates — expose flows through new registry
9. ws-pf/network-monitor-fix — PortForwardError type fix
10. ws-pf/tauri-integration — tauri command wiring
11. ws-pf/kftui-integration — kftui integration (top)

## Why?

The Tauri commands for starting and stopping port-forwards referenced the old `CHILD_PROCESSES` map. They are updated to use `PORT_FORWARD_REGISTRY`. `init_check.rs` adds the tracing subscriber initialization needed by the refactored backend.

## What?

- modified `commands/portforward.rs`, `commands/kubecontext.rs`, `main.rs`, `init_check.rs`, `Cargo.toml`
