### PR TITLE
fix: bypass HTTP logging for websocket tunnels

### DIFF
--- a/crates/kftray-http-logs/src/http_response_analyzer.rs
+++ b/crates/kftray-http-logs/src/http_response_analyzer.rs
@@ -80,18 +80,30 @@ impl HttpResponseAnalyzer {
     }
 
     pub fn is_websocket_upgrade(response_data: &[u8]) -> bool {
-        if let Some(headers_end) = find_headers_end(response_data) {
-            let header_section = &response_data[..headers_end];
-            return std::str::from_utf8(header_section)
-                .map(|h| {
-                    let h_lower = h.to_lowercase();
-                    h_lower.contains("upgrade: websocket")
-                        && h_lower.contains("connection: upgrade")
-                        && h_lower.contains("sec-websocket-accept:")
-                })
-                .unwrap_or(false);
+        let mut headers = [httparse::EMPTY_HEADER; 64];
+        let mut response = httparse::Response::new(&mut headers);
+        if !matches!(
+            response.parse(response_data),
+            Ok(httparse::Status::Complete(_))
+        ) || response.code != Some(101)
+        {
+            return false;
         }
-        false
+        let has_token = |name: &str, token: &str| {
+            response.headers.iter().any(|header| {
+                header.name.eq_ignore_ascii_case(name)
+                    && std::str::from_utf8(header.value).is_ok_and(|value| {
+                        value
+                            .split(',')
+                            .any(|part| part.trim().eq_ignore_ascii_case(token))
+                    })
+            })
+        };
+        has_token("upgrade", "websocket")
+            && has_token("connection", "upgrade")
+            && response.headers.iter().any(|header| {
+                header.name.eq_ignore_ascii_case("sec-websocket-accept") && !header.value.is_empty()
+            })
     }
 
     pub fn appears_complete(
@@ -359,6 +371,24 @@ mod tests {
         ));
         assert!(!HttpResponseAnalyzer::is_websocket_upgrade(
             no_headers_response
+        ));
+        let rejected_with_upgrade_headers = String::from_utf8(websocket_response.to_vec())
+            .unwrap()
+            .replace("101 Switching Protocols", "200 OK");
+        assert!(!HttpResponseAnalyzer::is_websocket_upgrade(
+            rejected_with_upgrade_headers.as_bytes()
+        ));
+        let token_list = String::from_utf8(websocket_response.to_vec())
+            .unwrap()
+            .replace("Connection: Upgrade", "cOnNeCtIoN: keep-alive, Upgrade");
+        assert!(HttpResponseAnalyzer::is_websocket_upgrade(
+            token_list.as_bytes()
+        ));
+        let unrelated_header = String::from_utf8(websocket_response.to_vec())
+            .unwrap()
+            .replace("Upgrade: websocket", "X-Upgrade: websocket");
+        assert!(!HttpResponseAnalyzer::is_websocket_upgrade(
+            unrelated_header.as_bytes()
         ));
     }
 

--- a/crates/kftray-portforward/src/kube/tcp_forwarder.rs
+++ b/crates/kftray-portforward/src/kube/tcp_forwarder.rs
@@ -290,14 +290,6 @@ impl TcpForwarder {
                     } else if should_log {
                         if let Some(ref mut req_buf) = request_buffer.as_mut() {
                             req_buf.extend_from_slice(&buffer[..n]);
-                            if Self::is_websocket_upgrade_request(req_buf) {
-                                websocket_tunnel_mode.store(true, Ordering::SeqCst);
-                                if let Err(e) = upstream_writer.write_all(req_buf).await {
-                                    return Err(e.into());
-                                }
-                                req_buf.clear();
-                                continue;
-                            }
                             let maybe_logger = {
                                 let guard = logger.lock().await;
                                 guard.clone()
@@ -609,22 +601,6 @@ impl TcpForwarder {
         false
     }
 
-    fn is_websocket_upgrade_request(request_data: &[u8]) -> bool {
-        let Ok(request) = std::str::from_utf8(request_data) else {
-            return false;
-        };
-
-        let headers = match request.split_once("\r\n\r\n") {
-            Some((headers, _)) => headers,
-            None => request,
-        }
-        .to_ascii_lowercase();
-
-        headers.contains("upgrade: websocket")
-            && headers.contains("connection: upgrade")
-            && headers.contains("sec-websocket-key:")
-    }
-
     fn can_clear_response_buffer_static(state: &ResponseState) -> bool {
         if state.is_chunked {
             state.found_end_marker
@@ -693,23 +669,6 @@ mod tests {
 
         let result = forwarder.initialize_logger(8080).await;
         assert!(result.is_ok());
-    }
-
-    #[test]
-    fn test_detect_websocket_upgrade_request() {
-        let request = concat!(
-            "GET /socket HTTP/1.1\r\n",
-            "Host: 127.0.0.1:18790\r\n",
-            "Connection: Upgrade\r\n",
-            "Upgrade: websocket\r\n",
-            "Sec-WebSocket-Key: test-key\r\n\r\n",
-        )
-        .as_bytes();
-
-        assert!(TcpForwarder::is_websocket_upgrade_request(request));
-        assert!(!TcpForwarder::is_websocket_upgrade_request(
-            b"GET / HTTP/1.1\r\nHost: localhost\r\n\r\n"
-        ));
     }
 
     #[tokio::test]
@@ -809,6 +768,7 @@ mod tests {
         let (_, log_subscriber) = tokio::sync::broadcast::channel(1);
 
         let logger = Arc::new(Mutex::new(None));
+        let websocket_tunnel_mode = Arc::new(AtomicBool::new(false));
         let result = TcpForwarder::forward_client_to_upstream(
             logger,
             forwarder.config_id,
@@ -818,6 +778,7 @@ mod tests {
             cancellation_token,
             log_subscriber,
             8080,
+            websocket_tunnel_mode,
         )
         .await;
 
@@ -855,6 +816,7 @@ mod tests {
         let (_, log_subscriber) = tokio::sync::broadcast::channel(1);
 
         let logger = Arc::new(Mutex::new(None));
+        let websocket_tunnel_mode = Arc::new(AtomicBool::new(false));
         let result = TcpForwarder::forward_upstream_to_client(
             logger,
             forwarder.config_id,
@@ -864,6 +826,7 @@ mod tests {
             cancellation_token,
             log_subscriber,
             8080,
+            websocket_tunnel_mode,
         )
         .await;
 

--- a/crates/kftray-portforward/src/kube/tcp_forwarder.rs
+++ b/crates/kftray-portforward/src/kube/tcp_forwarder.rs
@@ -431,15 +431,17 @@ impl TcpForwarder {
                         continue;
                     }
 
-                    let is_websocket_upgrade_response = should_log
-                        && kftray_http_logs::http_response_analyzer::HttpResponseAnalyzer::is_websocket_upgrade(&buffer[..n]);
+                    let is_websocket_upgrade_response = if should_log
+                        && let Some(ref mut state) = response_state.as_mut() {
+                            Self::handle_response_logging_static(&buffer[..n], state, &logger, &request_id).await
+                        } else {
+                            false
+                        };
+
                     if is_websocket_upgrade_response {
                         websocket_tunnel_mode.store(true, Ordering::SeqCst);
                         response_state = None;
                         should_log = false;
-                    } else if should_log
-                        && let Some(ref mut state) = response_state.as_mut() {
-                            Self::handle_response_logging_static(&buffer[..n], state, &logger, &request_id).await;
                     }
 
                     if let Err(e) = client_writer.write_all(&buffer[..n]).await {
@@ -514,7 +516,7 @@ impl TcpForwarder {
     async fn handle_response_logging_static(
         buffer: &[u8], state: &mut ResponseState, logger: &Arc<Mutex<Option<Arc<Logger>>>>,
         request_id: &Arc<Mutex<Option<String>>>,
-    ) {
+    ) -> bool {
         let req_id_guard = request_id.lock().await;
         let current_req_id = req_id_guard.clone();
         drop(req_id_guard);
@@ -544,6 +546,9 @@ impl TcpForwarder {
         );
 
         state.buffer.extend_from_slice(buffer);
+        if kftray_http_logs::http_response_analyzer::HttpResponseAnalyzer::is_websocket_upgrade(&state.buffer) {
+            return true;
+        }
 
         if !state.current_response_logged {
             let maybe_logger = {
@@ -564,6 +569,8 @@ impl TcpForwarder {
                 }
             }
         }
+
+        false
     }
 
     fn should_log_response_static(state: &mut ResponseState) -> bool {

--- a/crates/kftray-portforward/src/kube/tcp_forwarder.rs
+++ b/crates/kftray-portforward/src/kube/tcp_forwarder.rs
@@ -1,4 +1,8 @@
 use std::sync::Arc;
+use std::sync::atomic::{
+    AtomicBool,
+    Ordering,
+};
 use std::time::Duration;
 
 use tokio::io::{
@@ -149,6 +153,7 @@ impl TcpForwarder {
                 Arc::new(Mutex::new(self.logger.take().map(Arc::new)));
 
             let request_id = Arc::new(Mutex::new(None));
+            let websocket_tunnel_mode = Arc::new(AtomicBool::new(false));
             let mut client_conn_guard = client_conn.lock().await;
             let (mut client_reader, mut client_writer) = tokio::io::split(&mut *client_conn_guard);
             let (mut upstream_reader, mut upstream_writer) = tokio::io::split(upstream_conn);
@@ -162,6 +167,7 @@ impl TcpForwarder {
                 cancellation_token.clone(),
                 log_subscriber.resubscribe(),
                 local_port,
+                Arc::clone(&websocket_tunnel_mode),
             );
 
             let upstream_to_client = Self::forward_upstream_to_client(
@@ -173,6 +179,7 @@ impl TcpForwarder {
                 cancellation_token.clone(),
                 log_subscriber,
                 local_port,
+                Arc::clone(&websocket_tunnel_mode),
             );
 
             let result = tokio::try_join!(client_to_upstream, upstream_to_client);
@@ -255,7 +262,7 @@ impl TcpForwarder {
         mut log_subscriber: tokio::sync::broadcast::Receiver<
             crate::kube::http_log_watcher::HttpLogStateEvent,
         >,
-        local_port: u16,
+        local_port: u16, websocket_tunnel_mode: Arc<AtomicBool>,
     ) -> anyhow::Result<()> {
         let mut buffer = [0; BUFFER_SIZE];
         let mut should_log = {
@@ -276,9 +283,21 @@ impl TcpForwarder {
                         break;
                     }
 
-                    if should_log {
+                    if websocket_tunnel_mode.load(Ordering::SeqCst) {
+                        if let Err(e) = upstream_writer.write_all(&buffer[..n]).await {
+                            return Err(e.into());
+                        }
+                    } else if should_log {
                         if let Some(ref mut req_buf) = request_buffer.as_mut() {
                             req_buf.extend_from_slice(&buffer[..n]);
+                            if Self::is_websocket_upgrade_request(req_buf) {
+                                websocket_tunnel_mode.store(true, Ordering::SeqCst);
+                                if let Err(e) = upstream_writer.write_all(req_buf).await {
+                                    return Err(e.into());
+                                }
+                                req_buf.clear();
+                                continue;
+                            }
                             let maybe_logger = {
                                 let guard = logger.lock().await;
                                 guard.clone()
@@ -363,7 +382,7 @@ impl TcpForwarder {
         mut log_subscriber: tokio::sync::broadcast::Receiver<
             crate::kube::http_log_watcher::HttpLogStateEvent,
         >,
-        local_port: u16,
+        local_port: u16, websocket_tunnel_mode: Arc<AtomicBool>,
     ) -> anyhow::Result<()> {
         let mut buffer = [0; BUFFER_SIZE];
         let mut should_log = {
@@ -396,6 +415,7 @@ impl TcpForwarder {
 
                     if n == 0 {
                         if should_log
+                            && !websocket_tunnel_mode.load(Ordering::SeqCst)
                             && let Some(ref mut state) = response_state.as_mut() {
                                 let maybe_logger = {
                                     let guard = logger.lock().await;
@@ -412,10 +432,23 @@ impl TcpForwarder {
                         break;
                     }
 
-                    if should_log
+                    if websocket_tunnel_mode.load(Ordering::SeqCst) {
+                        if let Err(e) = client_writer.write_all(&buffer[..n]).await {
+                            return Err(e.into());
+                        }
+                        continue;
+                    }
+
+                    let is_websocket_upgrade_response = should_log
+                        && kftray_http_logs::http_response_analyzer::HttpResponseAnalyzer::is_websocket_upgrade(&buffer[..n]);
+                    if is_websocket_upgrade_response {
+                        websocket_tunnel_mode.store(true, Ordering::SeqCst);
+                        response_state = None;
+                        should_log = false;
+                    } else if should_log
                         && let Some(ref mut state) = response_state.as_mut() {
                             Self::handle_response_logging_static(&buffer[..n], state, &logger, &request_id).await;
-                        }
+                    }
 
                     if let Err(e) = client_writer.write_all(&buffer[..n]).await {
                         return Err(e.into());
@@ -576,6 +609,22 @@ impl TcpForwarder {
         false
     }
 
+    fn is_websocket_upgrade_request(request_data: &[u8]) -> bool {
+        let Ok(request) = std::str::from_utf8(request_data) else {
+            return false;
+        };
+
+        let headers = match request.split_once("\r\n\r\n") {
+            Some((headers, _)) => headers,
+            None => request,
+        }
+        .to_ascii_lowercase();
+
+        headers.contains("upgrade: websocket")
+            && headers.contains("connection: upgrade")
+            && headers.contains("sec-websocket-key:")
+    }
+
     fn can_clear_response_buffer_static(state: &ResponseState) -> bool {
         if state.is_chunked {
             state.found_end_marker
@@ -644,6 +693,23 @@ mod tests {
 
         let result = forwarder.initialize_logger(8080).await;
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_detect_websocket_upgrade_request() {
+        let request = concat!(
+            "GET /socket HTTP/1.1\r\n",
+            "Host: 127.0.0.1:18790\r\n",
+            "Connection: Upgrade\r\n",
+            "Upgrade: websocket\r\n",
+            "Sec-WebSocket-Key: test-key\r\n\r\n",
+        )
+        .as_bytes();
+
+        assert!(TcpForwarder::is_websocket_upgrade_request(request));
+        assert!(!TcpForwarder::is_websocket_upgrade_request(
+            b"GET / HTTP/1.1\r\nHost: localhost\r\n\r\n"
+        ));
     }
 
     #[tokio::test]

--- a/crates/kftray-portforward/src/kube/tcp_forwarder.rs
+++ b/crates/kftray-portforward/src/kube/tcp_forwarder.rs
@@ -22,6 +22,73 @@ use crate::kube::http_log_watcher::HttpLogStateWatcher;
 
 const BUFFER_SIZE: usize = 65536;
 
+#[derive(Default)]
+struct UpgradeDetector {
+    headers: Vec<u8>,
+    body_remaining: usize,
+    opaque: bool,
+}
+
+impl UpgradeDetector {
+    fn observe(&mut self, mut bytes: &[u8]) -> bool {
+        while !bytes.is_empty() && !self.opaque {
+            if self.body_remaining > 0 {
+                let consumed = self.body_remaining.min(bytes.len());
+                self.body_remaining -= consumed;
+                bytes = &bytes[consumed..];
+                continue;
+            }
+            // Bound header storage and never classify a response body as a
+            // handshake.
+            self.headers.push(bytes[0]);
+            bytes = &bytes[1..];
+            let prefix_len = self.headers.len().min(5);
+            if self.headers[..prefix_len] != b"HTTP/"[..prefix_len] {
+                self.opaque = true;
+                self.headers.clear();
+                return false;
+            }
+            if self.headers.ends_with(b"\r\n\r\n") {
+                if kftray_http_logs::http_response_analyzer::HttpResponseAnalyzer::is_websocket_upgrade(&self.headers) {
+                    self.headers.clear();
+                    return true;
+                }
+                let mut headers = [httparse::EMPTY_HEADER; 64];
+                let mut response = httparse::Response::new(&mut headers);
+                if matches!(
+                    response.parse(&self.headers),
+                    Ok(httparse::Status::Complete(_))
+                ) {
+                    let no_body = matches!(response.code, Some(100..=199) | Some(204) | Some(304));
+                    let length = response
+                        .headers
+                        .iter()
+                        .find(|h| h.name.eq_ignore_ascii_case("content-length"))
+                        .and_then(|h| std::str::from_utf8(h.value).ok())
+                        .and_then(|v| v.trim().parse::<usize>().ok());
+                    let transfer_encoded = response
+                        .headers
+                        .iter()
+                        .any(|h| h.name.eq_ignore_ascii_case("transfer-encoding"));
+                    // Unknown/streamed framing stays opaque; it must not create
+                    // a false upgrade.
+                    self.opaque = response.code == Some(101)
+                        || transfer_encoded
+                        || (!no_body && length.is_none());
+                    self.body_remaining = if no_body { 0 } else { length.unwrap_or(0) };
+                } else {
+                    self.opaque = true;
+                }
+                self.headers.clear();
+            } else if self.headers.len() == BUFFER_SIZE {
+                self.opaque = true;
+                self.headers.clear();
+            }
+        }
+        false
+    }
+}
+
 #[derive(Clone)]
 pub struct TcpForwarder {
     config_id: i64,
@@ -284,8 +351,9 @@ impl TcpForwarder {
                     }
 
                     if websocket_tunnel_mode.load(Ordering::SeqCst) {
-                        if let Err(e) = upstream_writer.write_all(&buffer[..n]).await {
-                            return Err(e.into());
+                        tokio::select! {
+                            result = upstream_writer.write_all(&buffer[..n]) => result?,
+                            _ = cancellation_token.cancelled() => break,
                         }
                     } else if should_log {
                         if let Some(ref mut req_buf) = request_buffer.as_mut() {
@@ -310,6 +378,9 @@ impl TcpForwarder {
                     }
                 },
                 log_event = log_subscriber.recv() => {
+                    if websocket_tunnel_mode.load(Ordering::SeqCst) {
+                        continue;
+                    }
                     if let Ok(event) = log_event
                         && event.config_id == config_id {
                             let needs_logger = event.enabled && {
@@ -396,6 +467,7 @@ impl TcpForwarder {
         } else {
             None
         };
+        let mut upgrade_detector = UpgradeDetector::default();
 
         loop {
             tokio::select! {
@@ -425,20 +497,22 @@ impl TcpForwarder {
                     }
 
                     if websocket_tunnel_mode.load(Ordering::SeqCst) {
-                        if let Err(e) = client_writer.write_all(&buffer[..n]).await {
-                            return Err(e.into());
+                        tokio::select! {
+                            result = client_writer.write_all(&buffer[..n]) => result?,
+                            _ = cancellation_token.cancelled() => break,
                         }
                         continue;
                     }
 
-                    let is_websocket_upgrade_response = if should_log
+                    let detected_upgrade = upgrade_detector.observe(&buffer[..n]);
+                    let logged_upgrade = if should_log
                         && let Some(ref mut state) = response_state.as_mut() {
                             Self::handle_response_logging_static(&buffer[..n], state, &logger, &request_id).await
                         } else {
                             false
                         };
 
-                    if is_websocket_upgrade_response {
+                    if logged_upgrade || detected_upgrade {
                         websocket_tunnel_mode.store(true, Ordering::SeqCst);
                         response_state = None;
                         should_log = false;
@@ -449,6 +523,9 @@ impl TcpForwarder {
                     }
                 },
                 log_event = log_subscriber.recv() => {
+                    if websocket_tunnel_mode.load(Ordering::SeqCst) {
+                        continue;
+                    }
                     if let Ok(event) = log_event
                         && event.config_id == config_id {
                             let needs_logger = event.enabled && {
@@ -691,7 +768,7 @@ mod tests {
         let forward_tunnel = tunnel.clone();
         let (mut upstream_reader, mut upstream_writer) = tokio::io::duplex(4096);
         let (mut client_writer, mut client_reader) = tokio::io::duplex(4096);
-        let (_events, subscriber) = tokio::sync::broadcast::channel(1);
+        let (events, subscriber) = tokio::sync::broadcast::channel(8);
         let forward = tokio::spawn(async move {
             TcpForwarder::forward_upstream_to_client(
                 logger,
@@ -733,6 +810,12 @@ mod tests {
             assert_eq!(tunnel.load(Ordering::SeqCst), expect_tunnel);
 
             if expect_tunnel || !logging_enabled {
+                events
+                    .send(crate::kube::http_log_watcher::HttpLogStateEvent::new(
+                        1, true,
+                    ))
+                    .unwrap();
+                tokio::task::yield_now().await;
                 upstream_writer.write_all(frame).await.unwrap();
                 let mut received = vec![0; frame.len()];
                 client_reader.read_exact(&mut received).await.unwrap();
@@ -793,7 +876,88 @@ mod tests {
 
     #[tokio::test]
     async fn test_websocket_without_logging_preserves_bytes() {
-        check_websocket_response_forwarding(WEBSOCKET_HANDSHAKE, 30, false, false).await;
+        check_websocket_response_forwarding(WEBSOCKET_HANDSHAKE, 30, false, true).await;
+    }
+
+    #[test]
+    fn test_upgrade_detector_is_bounded() {
+        let mut detector = UpgradeDetector::default();
+        assert!(!detector.observe(b"H"));
+        assert!(detector.observe(&WEBSOCKET_HANDSHAKE[1..]));
+        assert!(detector.headers.is_empty());
+        let mut oversized = b"HTTP/1.1 101 Switching Protocols\r\nX-Long: ".to_vec();
+        oversized.resize(BUFFER_SIZE * 2, b'x');
+        assert!(!detector.observe(&oversized));
+        assert!(detector.headers.is_empty());
+        assert!(!detector.observe(&vec![0x81; BUFFER_SIZE * 2]));
+        assert!(detector.headers.is_empty());
+    }
+
+    #[test]
+    fn test_upgrade_detector_does_not_classify_body_bytes() {
+        let mut detector = UpgradeDetector::default();
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n",
+            WEBSOCKET_HANDSHAKE.len()
+        );
+        assert!(!detector.observe(response.as_bytes()));
+        assert!(!detector.observe(WEBSOCKET_HANDSHAKE));
+        assert!(detector.observe(WEBSOCKET_HANDSHAKE));
+    }
+
+    #[tokio::test]
+    async fn test_raw_tunnel_blocked_writes_are_cancellable() {
+        for upstream_to_client in [false, true] {
+            let (mut reader, mut source) = tokio::io::duplex(1024);
+            let (mut writer, _unread_peer) = tokio::io::duplex(1);
+            source.write_all(&[0x81; 64]).await.unwrap();
+            let token = CancellationToken::new();
+            let cancel = token.clone();
+            let (_events, receiver) = tokio::sync::broadcast::channel(1);
+            let mut forward = tokio::spawn(async move {
+                let logger = Arc::new(Mutex::new(None));
+                let request_id = Arc::new(Mutex::new(None));
+                let tunnel = Arc::new(AtomicBool::new(true));
+                if upstream_to_client {
+                    TcpForwarder::forward_upstream_to_client(
+                        logger,
+                        1,
+                        &mut reader,
+                        &mut writer,
+                        request_id,
+                        token,
+                        receiver,
+                        8080,
+                        tunnel,
+                    )
+                    .await
+                } else {
+                    TcpForwarder::forward_client_to_upstream(
+                        logger,
+                        1,
+                        &mut reader,
+                        &mut writer,
+                        request_id,
+                        token,
+                        receiver,
+                        8080,
+                        tunnel,
+                    )
+                    .await
+                }
+            });
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            assert!(!forward.is_finished());
+            cancel.cancel();
+            let result = tokio::time::timeout(Duration::from_secs(1), &mut forward).await;
+            if result.is_err() {
+                forward.abort();
+            }
+            result
+                .expect("cancellation must settle a blocked raw write")
+                .unwrap()
+                .unwrap();
+        }
     }
 
     #[tokio::test]

--- a/crates/kftray-portforward/src/kube/tcp_forwarder.rs
+++ b/crates/kftray-portforward/src/kube/tcp_forwarder.rs
@@ -546,8 +546,17 @@ impl TcpForwarder {
         );
 
         state.buffer.extend_from_slice(buffer);
-        if kftray_http_logs::http_response_analyzer::HttpResponseAnalyzer::is_websocket_upgrade(&state.buffer) {
-            return true;
+        let is_websocket_upgrade =
+            kftray_http_logs::http_response_analyzer::HttpResponseAnalyzer::is_websocket_upgrade(
+                &state.buffer,
+            );
+        if is_websocket_upgrade {
+            // A read may contain both the handshake and the first WebSocket
+            // frame. Log only the complete HTTP headers; forwarding
+            // still uses the original read.
+            if let Some(headers_end) = state.buffer.windows(4).position(|w| w == b"\r\n\r\n") {
+                state.buffer.truncate(headers_end + 4);
+            }
         }
 
         if !state.current_response_logged {
@@ -570,7 +579,9 @@ impl TcpForwarder {
             }
         }
 
-        false
+        // The caller switches to raw forwarding only after the handshake is
+        // logged.
+        is_websocket_upgrade
     }
 
     fn should_log_response_static(state: &mut ResponseState) -> bool {
@@ -653,6 +664,137 @@ impl ResponseState {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const WEBSOCKET_HANDSHAKE: &[u8] = b"HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: test-accept\r\n\r\n";
+
+    async fn check_websocket_response_forwarding(
+        response: &[u8], split_at: usize, logging_enabled: bool, expect_tunnel: bool,
+    ) {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let log_path = temp_dir.path().join("websocket.log");
+        let http_logger = Arc::new(
+            Logger::new(
+                kftray_http_logs::LogConfig::new(temp_dir.path().to_path_buf()),
+                log_path.clone(),
+            )
+            .await
+            .unwrap(),
+        );
+        let req_id = http_logger
+            .log_request(bytes::Bytes::from_static(
+                b"GET /websocket HTTP/1.1\r\nHost: example.test\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n",
+            ))
+            .await;
+        let logger = Arc::new(Mutex::new(logging_enabled.then(|| http_logger.clone())));
+        let request_id = Arc::new(Mutex::new(Some(req_id)));
+        let tunnel = Arc::new(AtomicBool::new(false));
+        let forward_tunnel = tunnel.clone();
+        let (mut upstream_reader, mut upstream_writer) = tokio::io::duplex(4096);
+        let (mut client_writer, mut client_reader) = tokio::io::duplex(4096);
+        let (_events, subscriber) = tokio::sync::broadcast::channel(1);
+        let forward = tokio::spawn(async move {
+            TcpForwarder::forward_upstream_to_client(
+                logger,
+                1,
+                &mut upstream_reader,
+                &mut client_writer,
+                request_id,
+                CancellationToken::new(),
+                subscriber,
+                8080,
+                forward_tunnel,
+            )
+            .await
+            .unwrap();
+        });
+
+        tokio::time::timeout(Duration::from_secs(5), async {
+            upstream_writer
+                .write_all(&response[..split_at])
+                .await
+                .unwrap();
+            let mut first = vec![0; split_at];
+            client_reader.read_exact(&mut first).await.unwrap();
+            assert_eq!(first, response[..split_at]);
+            assert!(
+                !tunnel.load(Ordering::SeqCst),
+                "incomplete headers must not switch modes"
+            );
+
+            let frame = b"\x81\x0dframe-payload";
+            let mut last = response[split_at..].to_vec();
+            if expect_tunnel || !logging_enabled {
+                last.extend_from_slice(frame);
+            }
+            upstream_writer.write_all(&last).await.unwrap();
+            let mut received = vec![0; last.len()];
+            client_reader.read_exact(&mut received).await.unwrap();
+            assert_eq!(received, last, "coalesced frame bytes must be preserved");
+            assert_eq!(tunnel.load(Ordering::SeqCst), expect_tunnel);
+
+            if expect_tunnel || !logging_enabled {
+                upstream_writer.write_all(frame).await.unwrap();
+                let mut received = vec![0; frame.len()];
+                client_reader.read_exact(&mut received).await.unwrap();
+                assert_eq!(received, frame, "later frame bytes must be preserved");
+            }
+            upstream_writer.shutdown().await.unwrap();
+            forward.await.unwrap();
+        })
+        .await
+        .expect("forwarding should not stall");
+
+        let status = std::str::from_utf8(response)
+            .unwrap()
+            .lines()
+            .next()
+            .unwrap();
+        if logging_enabled {
+            tokio::time::timeout(Duration::from_secs(5), async {
+                loop {
+                    http_logger.flush().await.unwrap();
+                    let contents = tokio::fs::read_to_string(&log_path).await.unwrap();
+                    if contents.contains(status) {
+                        break;
+                    }
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                }
+            })
+            .await
+            .expect("the HTTP response must be logged before leaving HTTP mode");
+        }
+        http_logger.shutdown().await;
+        let contents = tokio::fs::read_to_string(&log_path).await.unwrap();
+        assert_eq!(
+            contents.matches(status).count(),
+            usize::from(logging_enabled)
+        );
+        assert!(
+            !contents.contains("frame-payload"),
+            "WebSocket frames are not HTTP log entries"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_websocket_handshake_logged_before_tunnel() {
+        check_websocket_response_forwarding(WEBSOCKET_HANDSHAKE, 30, true, true).await;
+    }
+
+    #[tokio::test]
+    async fn test_websocket_rejection_stays_in_http_mode() {
+        check_websocket_response_forwarding(
+            b"HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\n\r\n",
+            15,
+            true,
+            false,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_websocket_without_logging_preserves_bytes() {
+        check_websocket_response_forwarding(WEBSOCKET_HANDSHAKE, 30, false, false).await;
+    }
 
     #[tokio::test]
     async fn test_new() {


### PR DESCRIPTION
## Summary

- Keep the accepted WebSocket handshake visible in the HTTP log before switching both directions to raw forwarding.
- Exclude coalesced WebSocket frame bytes from the handshake log while forwarding the original bytes unchanged.
- Cover split handshake responses, rejected upgrades, and logging-disabled byte forwarding with transport-level tests.

## Scope

This is an HTTP-logging-path improvement, not a demonstrated fix for #666. I have not reproduced the OpenClaw gateway failure on main versus this branch with HTTP logging enabled. The default logging-disabled path already forwards bytes unchanged, so the original gateway diagnosis remains open.

## Validation

- All 12 focused TCP-forwarder tests and 14 shared response-analyzer tests pass at `5ae19522`.
- Reintroducing the original handshake-log bug, missing status validation, logging-dependent detection, or uncancellable raw write makes the corresponding regression fail. Restoring the fixes passes the complete focused suites again.
- Targeted nightly rustfmt and diff checks pass. Local tests use installed OpenSSL plus isolated D-Bus development headers; repository dependency and vendored-build settings are unchanged.
- The [replacement Windows proof](https://github.com/eugene-harold-krabs/kftray/actions/runs/34263255309) is running in the agent-owned fork at workflow commit `ff989920` with source commit `5ae19522`. The earlier proof run was canceled as superseded. No successful Windows artifact or gateway reproduction is claimed yet.

## Review follow-up

- Require a parsed HTTP 101 response, actual upgrade header names, and connection/upgrade tokens.
- Keep a bounded response-header detector active independently of logging, without treating fixed-length response body bytes as upgrade headers. Unknown framing stays opaque to the detector.
- Preserve tunnel mode when HTTP logging settings change, and make both raw write directions cancellable under backpressure.
