### PR TITLE
chore: fix clippy lints in the helper on Windows

### DIFF
--- a/crates/kftray-helper/src/auth.rs
+++ b/crates/kftray-helper/src/auth.rs
@@ -3,6 +3,7 @@ use std::time::{
     UNIX_EPOCH,
 };
 
+#[cfg(unix)]
 use log::{
     debug,
     info,
@@ -212,23 +213,4 @@ fn get_authorized_user_uid() -> u32 {
     let current_uid = unsafe { libc::getuid() };
     info!("No specific authorized UID found, falling back to current UID: {current_uid}");
     current_uid
-}
-
-#[cfg(windows)]
-pub fn validate_peer_credentials(
-    _pipe_handle: windows::Win32::Foundation::HANDLE,
-) -> Result<(), HelperError> {
-    Ok(())
-}
-
-#[cfg(not(any(unix, windows)))]
-fn get_authorized_user_uid() -> u32 {
-    warn!("Unsupported platform: No UID-based authorization, using default");
-    0
-}
-
-#[cfg(not(any(unix, windows)))]
-pub fn validate_peer_credentials<T>(_stream: &T) -> Result<(), HelperError> {
-    warn!("Unsupported platform: Peer credential validation skipped");
-    Ok(())
 }

--- a/crates/kftray-helper/src/client/socket_comm.rs
+++ b/crates/kftray-helper/src/client/socket_comm.rs
@@ -1,3 +1,4 @@
+#[cfg(unix)]
 use std::io;
 #[cfg(unix)]
 use std::os::unix::net::UnixStream;

--- a/crates/kftray-helper/src/platforms/windows.rs
+++ b/crates/kftray-helper/src/platforms/windows.rs
@@ -1,5 +1,4 @@
 use std::ffi::OsString;
-use std::path::PathBuf;
 use std::time::Duration;
 
 #[cfg(target_os = "windows")]


### PR DESCRIPTION
Rust 1.98 flags the `log` and `std::io` imports in `kftray-helper` as unused on Windows because every use sits behind `cfg(unix)`, and `PathBuf` in `platforms/windows.rs` was unused on every target. The Windows `validate_peer_credentials` stub and the non-unix fallback had no caller and are removed.

Verified with `cargo clippy -p kftray-helper --all-targets --all-features -- -D warnings` on macOS, on Linux (Docker, rust:1.98) and cross-checked on `x86_64-pc-windows-gnu`, where the unpatched crate reproduces the four errors from the Windows job.